### PR TITLE
feat: add paused subscription lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,25 @@ Fields:
 
 - `id`
 - `customer_id`
-- `status`: `active`, `cancelled`
+- `status`: `active`, `paused`, `cancelled`
 - `amount_cents`
 - `current_period_start`
 - `current_period_end`
-- AASM timestamp fields: `active_at`, `cancelled_at`
-- `cancellation_reason`
+- AASM timestamp fields: `active_at`, `paused_at`, `cancelled_at`
+- lifecycle metadata: `pause_reason`, `resumed_at`, `resume_reason`, `cancellation_reason`, `state_version`
 - timestamps
 
 Implemented behavior:
 
 - Belongs to a customer.
 - Has many invoices.
+- Supports `active -> paused -> active`, `active -> cancelled`, and `paused -> cancelled` lifecycle transitions.
+- Active subscriptions are billable and service-accessible.
+- Paused subscriptions are not billable and not service-accessible.
+- Resuming a paused subscription refreshes `active_at`, extends `current_period_end` by the pause duration, and re-enqueues existing scheduled payment attempts.
+- Cancelled subscriptions are terminal.
 - Can issue a draft invoice for its current billing period via `issue_new_invoice!`.
+- Has a lock-and-recheck invoice issuing path via `issue_new_invoice_if_due!`.
 - Has a uniqueness-protected invoice period through the invoice table/index.
 - Has scopes intended to find active subscriptions due for billing and avoid duplicate invoices.
 
@@ -113,22 +119,28 @@ The intended flow in the current code is:
 
 1. `PaymentScheduler#run!`
    - Finds active subscriptions due for billing.
-   - Locks rows with `FOR UPDATE SKIP LOCKED`.
-   - Creates a draft invoice.
-   - Publishes `invoice.created`.
+   - Locks and re-checks each subscription inside `issue_new_invoice_if_due!` before creating a draft invoice.
+   - Enqueues `invoice.created` in the outbox.
 
 2. `InvoiceConsumer`
    - Consumes `invoice.created`.
+   - Deduplicates the message with `ProcessedMessage`.
+   - Re-locks and re-checks invoice/subscription state and message version.
    - Opens a draft invoice.
    - Creates the first payment attempt.
    - Schedules the payment attempt.
-   - Publishes `billing.attempt.new` with `payment_attempt_id`.
+   - Enqueues `billing.attempt.new` in the outbox with `payment_attempt_id` and subscription state version.
 
 3. `BillingProcessorConsumer`
    - Consumes `billing.attempt.*`.
+   - Deduplicates the message with `ProcessedMessage`.
    - Loads a payment attempt.
+   - Re-checks that the payment attempt is scheduled and the subscription is active.
+   - Records `billing.payment.skipped` when the attempt is not currently processable.
    - Calls `ProcessPaymentService` with `PaymentGatewayApiMock`.
-   - Publishes `billing.payment.full.success` on success.
+   - Enqueues `billing.payment.full.success` in the outbox on success.
+   - Enqueues `billing.payment.failed` for gateway/insufficient-funds/system failures.
+   - Raises on retryable system failures so Hutch can nack/dead-letter according to RabbitMQ policy.
 
 4. `ProcessPaymentService`
    - Attempts to move a payment attempt to `processing`.
@@ -157,10 +169,10 @@ The previous documentation described several capabilities that are not implement
 
 ### Partially implemented or currently inconsistent
 
-- **Message delivery guarantees**: Hutch publisher confirms are configured, but the app does not implement an outbox, inbox, idempotency keys, deduplication table, or transactional message publishing. Treat RabbitMQ delivery as at-least-once and make consumers idempotent before depending on stronger guarantees.
+- **Message delivery guarantees**: Hutch publisher confirms, an outbox table, and a processed-message inbox table are present, but consumers should still be treated as at-least-once. Consumers re-check PostgreSQL state/version before side effects; exactly-once delivery is still not claimed.
 - **Concurrency**: invoice scheduling uses database transactions and `FOR UPDATE SKIP LOCKED`, and invoices have a unique index per subscription billing period. This helps prevent duplicate invoices, but it is not a full end-to-end concurrency/idempotency strategy.
 - **PostgreSQL high availability**: local Docker and Kubernetes manifests define a single PostgreSQL instance with a PVC. They do not configure one synchronous standby plus asynchronous standbys or otherwise guarantee zero RPO.
-- **Subscription state machine**: the enum only supports `active` and `cancelled`, while some AASM transitions reference `paused`.
+- **Pause side effects are intentionally limited**: pausing prevents new billing and service access, and removes unstarted current-period draft invoices, but it does not void open invoices, refund completed payments, or cancel already-created payment attempts.
 
 ## Rebilling Status
 
@@ -256,6 +268,8 @@ bin/brakeman
 ## Deployment and Infrastructure Notes
 
 - `.devcontainer/compose.yaml` starts Rails, PostgreSQL, and RabbitMQ for development/test use.
+- RabbitMQ/Hutch is configured for durable publishing defaults, publisher confirms, manual acknowledgements, low prefetch, quorum consumer queues, dead-letter routing, retry queues with TTL/DLX, and single-active-consumer queue arguments.
+- Subscription-scoped outbox messages are also mirrored to a consistent-hash exchange by `subscription_id` for shard-oriented processing/inspection; primary Hutch consumers still re-check PostgreSQL state/version because RabbitMQ delivery can be duplicate or out of order.
 - `k8s/` contains development-style Kubernetes manifests for single-instance PostgreSQL, RabbitMQ, and Rails deployments.
 - `config/deploy.yml` is the generated Kamal-style deployment scaffold and still contains placeholder hosts/image names.
 - The repository does not currently include production-grade PostgreSQL HA, RabbitMQ HA, secret management, backup/restore, or disaster-recovery configuration.

--- a/app/consumers/billing_consumer_queue_options.rb
+++ b/app/consumers/billing_consumer_queue_options.rb
@@ -1,0 +1,12 @@
+module BillingConsumerQueueOptions
+  DEAD_LETTER_EXCHANGE = "billing.events.dlx".freeze
+  DELIVERY_LIMIT = 5
+
+  def self.apply(consumer, dead_letter_routing_key:)
+    consumer.quorum_queue
+    consumer.arguments("x-dead-letter-exchange"     => DEAD_LETTER_EXCHANGE,
+                       "x-dead-letter-routing-key" => dead_letter_routing_key,
+                       "x-delivery-limit"          => DELIVERY_LIMIT,
+                       "x-single-active-consumer"  => true)
+  end
+end

--- a/app/consumers/billing_processor_consumer.rb
+++ b/app/consumers/billing_processor_consumer.rb
@@ -1,11 +1,29 @@
 class BillingProcessorConsumer
+  PaymentProcessingRetryableError = Class.new(StandardError)
+
   include Hutch::Consumer
+  include ConsumerIdempotency
+  include Dry::Monads[:result]
+
   consume "billing.attempt.*"
+  BillingConsumerQueueOptions.apply(self, dead_letter_routing_key: "billing.attempt.dead")
 
   def process(message)
+    process_once(message) { process_message(message) }
+  end
+
+  private
+
+  def process_message(message)
     logger.info "Message content: #{message.body.to_json}"
 
     payment_attempt = find_payment_attempt(message)
+    skipped_reason = unprocessable_reason(payment_attempt, message)
+
+    if skipped_reason
+      publish_payment_skipped(payment_attempt, skipped_reason)
+      return
+    end
 
     # we can inject different gateway implementation that supports #charge
     result = ProcessPaymentService.call(payment_attempt, PaymentGatewayApiMock.new)
@@ -15,33 +33,63 @@ class BillingProcessorConsumer
       publish_payment_success(result.value!)
     when Failure
       error_type, processed_attempt = result.failure
-      case error_type
-      when :insufficient_funds
-        # schedule retry with lower amount
-      when :gateway_error
-        # log error and notify support
-        # skip this branch for new
-      when :system_error
-        # log exception and retry later
-      when :already_processed
-        # handle duplicate processing attempt
-        # skip this branch for now
-      end
+      handle_payment_failure(error_type, processed_attempt)
     end
   end
 
-  private
-
   def find_payment_attempt(message)
-    attempt_id = message.body.fetch(:payment_attempt_id)
+    attempt_id = message_value(message, :payment_attempt_id)
     PaymentAttempt.find(attempt_id)
   end
 
-  def publish_payment_success(processed_attempt)
-    payload = { payment_attempt_id:  processed_attempt.id }
-    Hutch.publish("billing.payment.full.success", payload)
+  def unprocessable_reason(payment_attempt, message)
+    payment_attempt.reload
+    subscription = payment_attempt.subscription
+
+    return :not_scheduled unless payment_attempt.scheduled?
+    return :subscription_not_active unless subscription.active?
+    :stale_message if stale_message?(message, subscription)
   end
 
-  def publish_payment_retry(processed_attempt)
+  def handle_payment_failure(error_type, processed_attempt)
+    case error_type
+    when :insufficient_funds, :gateway_error
+      logger.warn("Payment attempt #{processed_attempt.id} failed: #{error_type}")
+      publish_payment_failed(processed_attempt, error_type)
+    when :system_error
+      logger.error("Payment attempt #{processed_attempt.id} failed with retryable system error")
+      publish_payment_failed(processed_attempt, error_type)
+      raise PaymentProcessingRetryableError, "Payment attempt #{processed_attempt.id} failed with system_error"
+    when :already_processed, :already_in_processing, :not_scheduled, :subscription_not_active
+      logger.info("Payment attempt #{processed_attempt.id} skipped: #{error_type}")
+      publish_payment_skipped(processed_attempt, error_type)
+    else
+      logger.error("Payment attempt #{processed_attempt.id} returned unknown failure: #{error_type}")
+      publish_payment_failed(processed_attempt, error_type)
+    end
+  end
+
+  def publish_payment_success(processed_attempt)
+    enqueue_payment_event("billing.payment.full.success", processed_attempt)
+  end
+
+  def publish_payment_failed(processed_attempt, failure_reason)
+    enqueue_payment_event("billing.payment.failed", processed_attempt, failure_reason: failure_reason)
+  end
+
+  def publish_payment_skipped(processed_attempt, skipped_reason)
+    enqueue_payment_event("billing.payment.skipped", processed_attempt, skipped_reason: skipped_reason)
+  end
+
+  def enqueue_payment_event(topic, processed_attempt, extra_payload = {})
+    subscription = processed_attempt.subscription
+    payload = { payment_attempt_id:         processed_attempt.id,
+                subscription_id:            subscription.id,
+                subscription_state_version: subscription.state_version }.merge(extra_payload)
+
+    OutboxMessage.enqueue!(topic:             topic,
+                           payload:           payload,
+                           aggregate:         subscription,
+                           aggregate_version: subscription.state_version)
   end
 end

--- a/app/consumers/consumer_idempotency.rb
+++ b/app/consumers/consumer_idempotency.rb
@@ -1,0 +1,47 @@
+require "digest"
+
+module ConsumerIdempotency
+  private
+
+  def process_once(message)
+    processed_message = claim_message(message)
+    return log_duplicate_message(message) unless processed_message
+
+    yield
+  rescue StandardError
+    processed_message&.destroy
+    raise
+  end
+
+  def claim_message(message)
+    ProcessedMessage.create!(consumer_name: self.class.name,
+                             message_id:     idempotency_message_id(message))
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => ex
+    raise unless duplicate_message_error?(ex)
+
+    nil
+  end
+
+  def log_duplicate_message(message)
+    logger.info "Ignoring duplicate message for #{self.class.name}: #{idempotency_message_id(message)}"
+  end
+
+  def message_value(message, key)
+    message.body.fetch(key) { message.body.fetch(key.to_s) }
+  end
+
+  def stale_message?(message, subscription)
+    message_version = message.body[:subscription_state_version] || message.body["subscription_state_version"]
+    message_version.present? && message_version.to_i < subscription.state_version
+  end
+
+  def idempotency_message_id(message)
+    explicit_message_id = message.message_id if message.respond_to?(:message_id)
+    explicit_message_id.presence || Digest::SHA256.hexdigest("#{self.class.name}:#{message.body.to_json}")
+  end
+
+  def duplicate_message_error?(error)
+    error.is_a?(ActiveRecord::RecordNotUnique) ||
+      (error.respond_to?(:record) && error.record&.errors&.of_kind?(:message_id, :taken))
+  end
+end

--- a/app/consumers/invoice_consumer.rb
+++ b/app/consumers/invoice_consumer.rb
@@ -1,18 +1,49 @@
 class InvoiceConsumer
   include Hutch::Consumer
+  include ConsumerIdempotency
+
   consume "invoice.created"
+  BillingConsumerQueueOptions.apply(self, dead_letter_routing_key: "invoice.created.dead")
 
   def process(message)
+    process_once(message) { process_message(message) }
+  end
+
+  private
+
+  def process_message(message)
     logger.info "Message content: #{message.body.to_json}"
 
-    invoice = Invoice.find(message.body.fetch(:invoice_id))
+    Invoice.transaction do
+      invoice = Invoice.lock.find(message_value(message, :invoice_id))
+      subscription = invoice.subscription
+      subscription.lock!
 
-    return unless invoice.draft?
+      next unless invoice.draft?
+      next unless subscription.active?
+      next if stale_message?(message, subscription)
 
-    invoice.open_new!
-    payment_attempt = invoice.payment_attempts.first
-    payment_attempt.schedule! if payment_attempt.pending?
+      invoice.open_new!
+      payment_attempt = invoice.payment_attempts.first
+      raise "Invoice #{invoice.id} did not create a payment attempt" unless payment_attempt
 
-    Hutch.publish("billing.attempt.new", { payment_attempt_id: payment_attempt.id })
+      payment_attempt.schedule! if payment_attempt.pending?
+      enqueue_billing_attempt(payment_attempt, subscription)
+    end
+  rescue ActiveRecord::RecordNotFound
+    logger.info "Ignoring stale invoice.created message: #{message.body.to_json}"
+  end
+
+  def enqueue_billing_attempt(payment_attempt, subscription)
+    OutboxMessage.enqueue!(topic:             "billing.attempt.new",
+                           payload:           billing_attempt_payload(payment_attempt, subscription),
+                           aggregate:         subscription,
+                           aggregate_version: subscription.state_version)
+  end
+
+  def billing_attempt_payload(payment_attempt, subscription)
+    { payment_attempt_id:          payment_attempt.id,
+      subscription_id:             subscription.id,
+      subscription_state_version:  subscription.state_version }
   end
 end

--- a/app/consumers/notification_consumer.rb
+++ b/app/consumers/notification_consumer.rb
@@ -8,16 +8,14 @@
 
 class NotificationConsumer
   include Hutch::Consumer
+  include ConsumerIdempotency
+
   consume "billing.*"
+  BillingConsumerQueueOptions.apply(self, dead_letter_routing_key: "billing.notification.dead")
 
   def process(message)
-    logger.info "Message content #{message.body.to_json}"
-  end
-
-  private
-
-  def find_payment_attempt(message)
-    attempt_id = message.body.fetch(:payment_attempt_id)
-    PaymentAttempt.find(attempt_id)
+    process_once(message) do
+      logger.info "Message content #{message.body.to_json}"
+    end
   end
 end

--- a/app/consumers/retry_manager_consumer.rb
+++ b/app/consumers/retry_manager_consumer.rb
@@ -4,16 +4,14 @@
 
 class RetryManagerConsumer
   include Hutch::Consumer
+  include ConsumerIdempotency
+
   consume "billing.payment.*"
+  BillingConsumerQueueOptions.apply(self, dead_letter_routing_key: "billing.retry.dead")
 
   def process(message)
-    logger.info "Message content #{message.body.to_json}"
-  end
-
-  private
-
-  def find_payment_attempt(message)
-    attempt_id = message.body.fetch(:payment_attempt_id)
-    PaymentAttempt.find(attempt_id)
+    process_once(message) do
+      logger.info "Message content #{message.body.to_json}"
+    end
   end
 end

--- a/app/models/outbox_message.rb
+++ b/app/models/outbox_message.rb
@@ -1,0 +1,17 @@
+class OutboxMessage < ApplicationRecord
+  validates :topic, presence: true
+  validates :payload, presence: true
+
+  scope :unpublished, -> { where(published_at: nil) }
+  scope :claimable, ->(locked_before) {
+    unpublished.where(locked_at: nil).or(unpublished.where(locked_at: ...locked_before))
+  }
+
+  def self.enqueue!(topic:, payload:, aggregate: nil, aggregate_version: nil)
+    create!(topic:             topic,
+            payload:           payload,
+            aggregate_type:    aggregate&.class&.name,
+            aggregate_id:      aggregate&.id,
+            aggregate_version: aggregate_version)
+  end
+end

--- a/app/models/processed_message.rb
+++ b/app/models/processed_message.rb
@@ -1,0 +1,4 @@
+class ProcessedMessage < ApplicationRecord
+  validates :consumer_name, presence: true
+  validates :message_id, presence: true, uniqueness: { scope: :consumer_name }
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -9,6 +9,11 @@
 #  cancelled_at         :datetime
 #  current_period_end   :datetime         not null
 #  current_period_start :datetime         not null
+#  pause_reason         :text
+#  paused_at            :datetime
+#  resume_reason        :text
+#  resumed_at           :datetime
+#  state_version        :integer          default(0), not null
 #  status               :enum             default(NULL), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
@@ -26,7 +31,7 @@
 class Subscription < ApplicationRecord
   include AASM
 
-  VALID_STATUSES = %i[active cancelled].freeze
+  VALID_STATUSES = %i[active paused cancelled].freeze
 
   enum :status, VALID_STATUSES.reduce({}) { |acc, v| acc.merge(v => v) }
   monetize :amount_cents
@@ -71,23 +76,42 @@ class Subscription < ApplicationRecord
        column:               :status,
        enum:                 true do
     state :active, initial: true
+    state :paused
     state :cancelled
 
-    event :resume do
-      transitions from: :paused, to: :active do
-        after do
-        end
-      end
+    event :pause, before: :record_pause_metadata do
+      transitions from: :active, to: :paused
     end
 
-    event :cancel do
-      transitions from: %i[active paused], to: :cancelled do
-        after do
-          cancelled_at = Time.current
-          cancellation_reason = cancellation_reason
-        end
-      end
+    event :resume, before: :record_resume_metadata do
+      transitions from: :paused, to: :active
     end
+
+    event :cancel, before: :record_cancellation_metadata do
+      transitions from: %i[active paused], to: :cancelled
+    end
+  end
+
+  def billable?
+    active?
+  end
+
+  def service_accessible?
+    active?
+  end
+
+  def terminal?
+    cancelled?
+  end
+
+  def due_for_payment_now?(buffer_hours: 24)
+    active? && current_period_end.between?(Time.current.beginning_of_day,
+                                           Time.current.end_of_day + buffer_hours.hours)
+  end
+
+  def invoice_for_current_period?
+    invoices.exists?(billing_period_start: current_period_start,
+                     billing_period_end:   current_period_end)
   end
 
   def issue_new_invoice!
@@ -99,7 +123,72 @@ class Subscription < ApplicationRecord
     end
   end
 
+  def issue_new_invoice_if_due!(buffer_hours: 24)
+    invoice = nil
+
+    self.class.transaction(isolation: :serializable) do
+      lock!
+
+      if due_for_payment_now?(buffer_hours: buffer_hours) && !invoice_for_current_period?
+        invoice = invoices.create!(draft_at:             Time.current,
+                                   amount_total:         amount,
+                                   billing_period_start: current_period_start,
+                                   billing_period_end:   current_period_end)
+        enqueue_invoice_created(invoice)
+      end
+    end
+
+    invoice
+  end
+
   def next_due_date
     current_period_end.next_weekday
+  end
+
+  def lifecycle_payload(reason: nil)
+    { subscription_id: id,
+      customer_id:     customer_id,
+      status:          status,
+      reason:          reason,
+      state_version:   state_version }
+  end
+
+  private
+
+  def record_pause_metadata(reason = nil)
+    self.pause_reason = reason
+    increment_state_version
+  end
+
+  def record_resume_metadata(reason = nil)
+    resumed_time = Time.current
+    pause_duration = resumed_time - paused_at if paused_at.present?
+
+    self.resume_reason = reason
+    self.resumed_at = resumed_time
+    self.current_period_end += pause_duration if pause_duration.present?
+    increment_state_version
+  end
+
+  def record_cancellation_metadata(reason = nil)
+    self.cancellation_reason = reason
+    increment_state_version
+  end
+
+  def enqueue_invoice_created(invoice)
+    OutboxMessage.enqueue!(topic:             "invoice.created",
+                           payload:           invoice_created_payload(invoice),
+                           aggregate:         self,
+                           aggregate_version: state_version)
+  end
+
+  def invoice_created_payload(invoice)
+    { invoice_id:                  invoice.id,
+      subscription_id:             id,
+      subscription_state_version:  state_version }
+  end
+
+  def increment_state_version
+    self.state_version += 1
   end
 end

--- a/app/services/billing_service.rb
+++ b/app/services/billing_service.rb
@@ -2,11 +2,13 @@ class BillingService < ApplicationService
   param :payment_attempt
 
   def call
-    payload = { payment_attempt_id: payment_attempt.id,
-                subscription_id:    payment_attempt.subscription.id }
+    payload = { payment_attempt_id:         payment_attempt.id,
+                subscription_id:            payment_attempt.subscription.id,
+                subscription_state_version: payment_attempt.subscription.state_version }
 
-    Hutch.publish("billing.attempt.new", payload)
-  rescue Hutch::ConnectionError => ex
-    logger.error("Hutch::ConnectionError: #{ex}")
+    OutboxMessage.enqueue!(topic:             "billing.attempt.new",
+                           payload:           payload,
+                           aggregate:         payment_attempt.subscription,
+                           aggregate_version: payment_attempt.subscription.state_version)
   end
 end

--- a/app/services/cancel_subscription_service.rb
+++ b/app/services/cancel_subscription_service.rb
@@ -1,0 +1,32 @@
+class CancelSubscriptionService < ApplicationService
+  include Dry::Monads[:result]
+
+  param :subscription
+  option :reason, optional: true
+
+  def call
+    Subscription.transaction do
+      subscription.lock!
+
+      return Success(subscription) if subscription.cancelled?
+
+      subscription.cancel!(reason)
+      enqueue_subscription_cancelled
+
+      Success(subscription)
+    end
+  end
+
+  private
+
+  def enqueue_subscription_cancelled
+    OutboxMessage.enqueue!(topic:             "subscription.cancelled",
+                           payload:           lifecycle_payload,
+                           aggregate:         subscription,
+                           aggregate_version: subscription.state_version)
+  end
+
+  def lifecycle_payload
+    subscription.lifecycle_payload(reason: reason)
+  end
+end

--- a/app/services/outbox_publisher_service.rb
+++ b/app/services/outbox_publisher_service.rb
@@ -1,0 +1,60 @@
+class OutboxPublisherService < ApplicationService
+  DEFAULT_BATCH_SIZE = 100
+  DEFAULT_LOCK_TIMEOUT = 15.minutes
+
+  option :batch_size, default: proc { DEFAULT_BATCH_SIZE }
+  option :lock_timeout, default: proc { DEFAULT_LOCK_TIMEOUT }
+
+  def call
+    claim_batch.each { |message| publish_message(message) }
+  end
+
+  private
+
+  def claim_batch
+    claimed_messages = []
+
+    OutboxMessage.transaction do
+      claimed_messages = OutboxMessage.claimable(Time.current - lock_timeout)
+                                      .order(:created_at)
+                                      .lock("FOR UPDATE SKIP LOCKED")
+                                      .limit(batch_size)
+                                      .to_a
+      OutboxMessage.where(id: claimed_messages.map(&:id)).update_all(locked_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    claimed_messages
+  end
+
+  def publish_message(message)
+    Hutch.publish(message.topic, message.payload, { message_id: message.id })
+    mirror_to_consistent_hash_exchange(message)
+    mark_published(message)
+  rescue StandardError => ex
+    mark_failed(message, ex)
+  end
+
+  def mark_published(message)
+    OutboxMessage.where(id: message.id).update_all(published_at: Time.current,
+                                                   locked_at:    nil,
+                                                   attempts:     message.attempts + 1,
+                                                   last_error:   nil,
+                                                   updated_at:   Time.current) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def mark_failed(message, error)
+    OutboxMessage.where(id: message.id).update_all(locked_at:  nil,
+                                                   attempts:   message.attempts + 1,
+                                                   last_error: error.message,
+                                                   updated_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def mirror_to_consistent_hash_exchange(message)
+    RabbitMqTopology.publish_to_consistent_hash(topic:           message.topic,
+                                                payload:          message.payload,
+                                                subscription_id:  message.payload["subscription_id"],
+                                                message_id:       message.id)
+  rescue StandardError => ex
+    Rails.logger.warn("Consistent-hash mirror publish failed for outbox #{message.id}: #{ex.class}: #{ex.message}")
+  end
+end

--- a/app/services/pause_subscription_service.rb
+++ b/app/services/pause_subscription_service.rb
@@ -1,0 +1,43 @@
+class PauseSubscriptionService < ApplicationService
+  include Dry::Monads[:result]
+
+  param :subscription
+  option :reason, optional: true
+
+  def call
+    Subscription.transaction do
+      subscription.lock!
+
+      return Success(subscription) if subscription.paused?
+      return Failure[:already_cancelled, subscription] if subscription.cancelled?
+
+      subscription.pause!(reason)
+      destroy_unstarted_current_period_draft_invoices
+      enqueue_subscription_paused
+
+      Success(subscription)
+    end
+  end
+
+  private
+
+  def destroy_unstarted_current_period_draft_invoices
+    subscription.invoices
+                .draft
+                .where(billing_period_start: subscription.current_period_start,
+                       billing_period_end:   subscription.current_period_end,
+                       payment_attempts_count: 0)
+                .delete_all
+  end
+
+  def enqueue_subscription_paused
+    OutboxMessage.enqueue!(topic:             "subscription.paused",
+                           payload:           lifecycle_payload,
+                           aggregate:         subscription,
+                           aggregate_version: subscription.state_version)
+  end
+
+  def lifecycle_payload
+    subscription.lifecycle_payload(reason: reason)
+  end
+end

--- a/app/services/process_payment_service.rb
+++ b/app/services/process_payment_service.rb
@@ -1,16 +1,27 @@
 class ProcessPaymentService < ApplicationService
   include Dry::Monads[:result]
 
+  SystemErrorResponse = Struct.new(:status, :transaction_id, :message, keyword_init: true) do
+    def to_h
+      { status:         status,
+        transaction_id: transaction_id,
+        message:        message }
+    end
+  end
+
   param :payment_attempt
   param :payment_gateway
 
   def call
-    # FIXME: probably skip on all other statuses except `scheduled`
     return Failure[:already_in_processing, payment_attempt] if payment_attempt.processing?
 
+    claim_result = claim_payment_attempt
+    return claim_result if claim_result.failure?
+
+    @response = process_payment
+
     ActiveRecord::Base.transaction(isolation: :serializable) do
-      payment_attempt.start_processing!
-      @response = process_payment
+      payment_attempt.reload
       handle_api_response
     end
   rescue StandardError => ex
@@ -20,6 +31,28 @@ class ProcessPaymentService < ApplicationService
   private
 
   attr_reader :response
+
+  def claim_payment_attempt
+    result = nil
+
+    ActiveRecord::Base.transaction(isolation: :serializable) do
+      payment_attempt.lock!
+      payment_attempt.subscription.lock!
+
+      result = validate_claimable_payment_attempt
+      payment_attempt.start_processing! if result.success?
+    end
+
+    result
+  end
+
+  def validate_claimable_payment_attempt
+    return Failure[:already_in_processing, payment_attempt] if payment_attempt.processing?
+    return Failure[:not_scheduled, payment_attempt] unless payment_attempt.scheduled?
+    return Failure[:subscription_not_active, payment_attempt] unless payment_attempt.subscription.active?
+
+    Success(payment_attempt)
+  end
 
   def process_payment
     payment_gateway.charge(
@@ -33,8 +66,9 @@ class ProcessPaymentService < ApplicationService
     when :success            then handle_api_success
     when :insufficient_funds then handle_api_insufficient_funds
     when :failed             then handle_api_failure
+    when :system_error       then handle_api_system_error
     else
-      raise StandardError.new("Unknow Payment Gateway API response status: #{response.status}")
+      raise StandardError.new("Unknown Payment Gateway API response status: #{response.status}")
     end
   end
 
@@ -53,8 +87,19 @@ class ProcessPaymentService < ApplicationService
     Failure[:gateway_error, payment_attempt]
   end
 
-  def handle_exception(ex)
+  def handle_api_system_error
     payment_attempt.fail!(response, :system_error)
     Failure[:system_error, payment_attempt]
+  end
+
+  def handle_exception(ex)
+    payment_attempt.fail!(response || system_error_response(ex), :system_error) if payment_attempt.processing?
+    Failure[:system_error, payment_attempt]
+  end
+
+  def system_error_response(ex)
+    SystemErrorResponse.new(status: :system_error,
+                            transaction_id: nil,
+                            message: ex.message)
   end
 end

--- a/app/services/resume_subscription_service.rb
+++ b/app/services/resume_subscription_service.rb
@@ -1,0 +1,52 @@
+class ResumeSubscriptionService < ApplicationService
+  include Dry::Monads[:result]
+
+  param :subscription
+  option :reason, optional: true
+
+  def call
+    Subscription.transaction do
+      subscription.lock!
+
+      return Success(subscription) if subscription.active?
+      return Failure[:already_cancelled, subscription] if subscription.cancelled?
+
+      subscription.resume!(reason)
+      enqueue_subscription_resumed
+      enqueue_scheduled_payment_attempts
+
+      Success(subscription)
+    end
+  end
+
+  private
+
+  def enqueue_subscription_resumed
+    OutboxMessage.enqueue!(topic:             "subscription.resumed",
+                           payload:           lifecycle_payload,
+                           aggregate:         subscription,
+                           aggregate_version: subscription.state_version)
+  end
+
+  def lifecycle_payload
+    subscription.lifecycle_payload(reason: reason)
+  end
+
+  def enqueue_scheduled_payment_attempts
+    PaymentAttempt.scheduled
+                  .joins(:invoice)
+                  .where(invoices: { subscription_id: subscription.id })
+                  .find_each do |payment_attempt|
+                    OutboxMessage.enqueue!(topic:             "billing.attempt.new",
+                                           payload:           billing_attempt_payload(payment_attempt),
+                                           aggregate:         subscription,
+                                           aggregate_version: subscription.state_version)
+                  end
+  end
+
+  def billing_attempt_payload(payment_attempt)
+    { payment_attempt_id:         payment_attempt.id,
+      subscription_id:            subscription.id,
+      subscription_state_version: subscription.state_version }
+  end
+end

--- a/config/hutch.yaml
+++ b/config/hutch.yaml
@@ -2,5 +2,9 @@ mq_username: guest
 mq_password: guest
 mq_host: rabbitmq
 mq_exchange: billing.events
+mq_exchange_type: topic
+mq_exchange_options:
+  durable: true
 mq_api_host: rabbitmq
+channel_prefetch: 1
 force_publisher_confirms: true

--- a/config/initializers/hutch.rb
+++ b/config/initializers/hutch.rb
@@ -1,7 +1,12 @@
+require Rails.root.join("lib/rabbit_mq_topology")
+
 Hutch::Config.load_from_file("config/hutch.yaml")
 
 begin
-  Hutch.connect unless Rails.env.test?
+  unless Rails.env.test?
+    Hutch.connect
+    RabbitMqTopology.declare!
+  end
 rescue Hutch::ConnectionError => ex
   Rails.logger.warn("Hutch::ConnectionError: #{ex}")
 end

--- a/db/migrate/20260425140000_add_paused_lifecycle_to_subscriptions.rb
+++ b/db/migrate/20260425140000_add_paused_lifecycle_to_subscriptions.rb
@@ -1,0 +1,17 @@
+class AddPausedLifecycleToSubscriptions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    execute "ALTER TYPE subscription_status ADD VALUE IF NOT EXISTS 'paused'"
+
+    add_column :subscriptions, :paused_at, :datetime unless column_exists?(:subscriptions, :paused_at)
+    add_column :subscriptions, :pause_reason, :text unless column_exists?(:subscriptions, :pause_reason)
+    add_column :subscriptions, :resumed_at, :datetime unless column_exists?(:subscriptions, :resumed_at)
+    add_column :subscriptions, :resume_reason, :text unless column_exists?(:subscriptions, :resume_reason)
+    add_column :subscriptions, :state_version, :integer, default: 0, null: false unless column_exists?(:subscriptions, :state_version)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260425140001_create_outbox_messages.rb
+++ b/db/migrate/20260425140001_create_outbox_messages.rb
@@ -1,0 +1,20 @@
+class CreateOutboxMessages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :outbox_messages, id: :uuid do |t|
+      t.string :topic, null: false
+      t.jsonb :payload, default: {}, null: false
+      t.string :aggregate_type
+      t.uuid :aggregate_id
+      t.integer :aggregate_version
+      t.datetime :published_at
+      t.integer :attempts, default: 0, null: false
+      t.text :last_error
+
+      t.timestamps
+    end
+
+    add_index :outbox_messages, :published_at
+    add_index :outbox_messages, %i[aggregate_type aggregate_id]
+    add_index :outbox_messages, %i[published_at created_at]
+  end
+end

--- a/db/migrate/20260425140002_create_processed_messages.rb
+++ b/db/migrate/20260425140002_create_processed_messages.rb
@@ -1,0 +1,12 @@
+class CreateProcessedMessages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :processed_messages, id: :uuid do |t|
+      t.string :consumer_name, null: false
+      t.string :message_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :processed_messages, %i[consumer_name message_id], unique: true
+  end
+end

--- a/db/migrate/20260425140003_add_locked_at_to_outbox_messages.rb
+++ b/db/migrate/20260425140003_add_locked_at_to_outbox_messages.rb
@@ -1,0 +1,6 @@
+class AddLockedAtToOutboxMessages < ActiveRecord::Migration[8.0]
+  def change
+    add_column :outbox_messages, :locked_at, :datetime
+    add_index :outbox_messages, :locked_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_28_170914) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_140003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -21,68 +21,99 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_28_170914) do
   create_enum "invoice_status", ["draft", "open", "paid", "partially_paid", "not_paid"]
   create_enum "payment_attempt_status", ["pending", "scheduled", "processing", "completed", "failed"]
   create_enum "payment_retry_strategy", ["initial", "remaining_balance"]
-  create_enum "subscription_status", ["active", "cancelled"]
+  create_enum "subscription_status", ["active", "cancelled", "paused"]
 
   create_table "customers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", null: false
-    t.text "email", null: false
     t.text "billing_address", null: false
     t.datetime "created_at", null: false
+    t.text "email", null: false
+    t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_customers_on_email", unique: true
   end
 
   create_table "invoices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.enum "status", default: "draft", null: false, enum_type: "invoice_status"
-    t.integer "amount_total_cents", default: 0, null: false
     t.integer "amount_paid_cents", default: 0, null: false
-    t.datetime "billing_period_start", null: false
+    t.integer "amount_total_cents", default: 0, null: false
     t.datetime "billing_period_end", null: false
-    t.datetime "next_retry_at"
-    t.integer "payment_attempts_count", default: 0, null: false
+    t.datetime "billing_period_start", null: false
+    t.datetime "created_at", null: false
     t.datetime "draft_at"
+    t.datetime "next_retry_at"
+    t.datetime "not_paid_at"
     t.datetime "open_at"
     t.datetime "paid_at"
     t.datetime "partially_paid_at"
-    t.datetime "not_paid_at"
+    t.integer "payment_attempts_count", default: 0, null: false
+    t.enum "status", default: "draft", null: false, enum_type: "invoice_status"
     t.uuid "subscription_id", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["subscription_id", "billing_period_start", "billing_period_end"], name: "idx_on_subscription_id_billing_period_start_billing_97b6392bf1", unique: true
     t.index ["subscription_id"], name: "index_invoices_on_subscription_id"
   end
 
+  create_table "outbox_messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "aggregate_id"
+    t.string "aggregate_type"
+    t.integer "aggregate_version"
+    t.integer "attempts", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.text "last_error"
+    t.datetime "locked_at"
+    t.jsonb "payload", default: {}, null: false
+    t.datetime "published_at"
+    t.string "topic", null: false
+    t.datetime "updated_at", null: false
+    t.index ["aggregate_type", "aggregate_id"], name: "index_outbox_messages_on_aggregate_type_and_aggregate_id"
+    t.index ["locked_at"], name: "index_outbox_messages_on_locked_at"
+    t.index ["published_at", "created_at"], name: "index_outbox_messages_on_published_at_and_created_at"
+    t.index ["published_at"], name: "index_outbox_messages_on_published_at"
+  end
+
   create_table "payment_attempts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.enum "status", default: "pending", null: false, enum_type: "payment_attempt_status"
-    t.enum "retry_strategy", enum_type: "payment_retry_strategy"
     t.integer "amount_attempted_cents", default: 0, null: false
     t.integer "attempt_number", null: false
-    t.text "gateway_transaction_id"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "failed_at"
     t.text "failure_reason"
     t.jsonb "gateway_response"
+    t.text "gateway_transaction_id"
+    t.uuid "invoice_id", null: false
     t.datetime "pending_at"
     t.datetime "processing_at"
+    t.enum "retry_strategy", enum_type: "payment_retry_strategy"
     t.datetime "scheduled_at"
-    t.datetime "completed_at"
-    t.datetime "failed_at"
-    t.uuid "invoice_id", null: false
-    t.datetime "created_at", null: false
+    t.enum "status", default: "pending", null: false, enum_type: "payment_attempt_status"
     t.datetime "updated_at", null: false
     t.index ["invoice_id", "status"], name: "index_payment_attempts_on_invoice_id_and_status", unique: true, where: "(status = ANY (ARRAY['pending'::payment_attempt_status, 'scheduled'::payment_attempt_status, 'processing'::payment_attempt_status]))"
     t.index ["invoice_id"], name: "index_payment_attempts_on_invoice_id"
     t.index ["scheduled_at"], name: "index_payment_attempts_on_scheduled_at"
   end
 
-  create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.enum "status", default: "active", null: false, enum_type: "subscription_status"
-    t.integer "amount_cents", default: 0, null: false
-    t.datetime "current_period_start", null: false
-    t.datetime "current_period_end", null: false
-    t.datetime "active_at"
-    t.datetime "cancelled_at"
-    t.text "cancellation_reason"
-    t.uuid "customer_id", null: false
+  create_table "processed_messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "consumer_name", null: false
     t.datetime "created_at", null: false
+    t.string "message_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["consumer_name", "message_id"], name: "index_processed_messages_on_consumer_name_and_message_id", unique: true
+  end
+
+  create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "active_at"
+    t.integer "amount_cents", default: 0, null: false
+    t.text "cancellation_reason"
+    t.datetime "cancelled_at"
+    t.datetime "created_at", null: false
+    t.datetime "current_period_end", null: false
+    t.datetime "current_period_start", null: false
+    t.uuid "customer_id", null: false
+    t.text "pause_reason"
+    t.datetime "paused_at"
+    t.text "resume_reason"
+    t.datetime "resumed_at"
+    t.integer "state_version", default: 0, null: false
+    t.enum "status", default: "active", null: false, enum_type: "subscription_status"
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["status", "current_period_end"], name: "index_subscriptions_on_status_and_current_period_end"

--- a/lib/payment_scheduler.rb
+++ b/lib/payment_scheduler.rb
@@ -16,17 +16,8 @@ class PaymentScheduler
 
   def run!
     Subscription.due_for_payment
-                .lock("FOR UPDATE SKIP LOCKED")
                 .find_each(batch_size: 25) do |subscription|
-                  subscription.issue_new_invoice!
-                  publish_invoice_created(subscription)
+                  subscription.issue_new_invoice_if_due!
                 end
-  end
-
-  private
-
-  def publish_invoice_created(subscription)
-    payload = { invoice_id: subscription.latest_invoice.id }
-    Hutch.publish("invoice.created", payload)
   end
 end

--- a/lib/rabbit_mq_topology.rb
+++ b/lib/rabbit_mq_topology.rb
@@ -1,0 +1,104 @@
+class RabbitMqTopology
+  MAIN_EXCHANGE = "billing.events".freeze
+  DEAD_LETTER_EXCHANGE = "billing.events.dlx".freeze
+  HASH_EXCHANGE = "billing.events.by_subscription".freeze
+  RETRY_EXCHANGE = "billing.events.retry".freeze
+  DEAD_LETTER_ROUTING_KEYS = %w[
+    billing.attempt.dead
+    billing.payment.skipped.dead
+    invoice.created.dead
+    billing.notification.dead
+    billing.retry.dead
+  ].freeze
+  RETRY_DELAYS = { "1m" => 60_000, "5m" => 300_000, "30m" => 1_800_000 }.freeze
+  SHARD_COUNT = 4
+
+  def self.declare!(broker = Hutch.broker)
+    return unless broker&.channel
+
+    new(broker.channel).declare!
+  rescue StandardError => ex
+    Rails.logger.warn("RabbitMQ topology declaration failed: #{ex.class}: #{ex.message}")
+  end
+
+  def self.publish_to_consistent_hash(topic:, payload:, subscription_id:, message_id:)
+    return unless Hutch.broker&.channel && subscription_id.present?
+
+    exchange = Hutch.broker.channel.exchange(HASH_EXCHANGE, type: "x-consistent-hash", durable: true)
+    exchange.publish(payload.to_json,
+                     routing_key:  subscription_id,
+                     persistent:   true,
+                     message_id:   message_id,
+                     content_type: "application/json",
+                     type:         topic)
+  end
+
+  def initialize(channel)
+    @channel = channel
+  end
+
+  def declare!
+    declare_exchanges
+    declare_dead_letter_queues
+    declare_retry_queues
+    declare_consistent_hash_shards
+  end
+
+  private
+
+  attr_reader :channel
+
+  def declare_exchanges
+    channel.exchange(MAIN_EXCHANGE, type: :topic, durable: true)
+    channel.exchange(DEAD_LETTER_EXCHANGE, type: :topic, durable: true)
+    channel.exchange(RETRY_EXCHANGE, type: :topic, durable: true)
+    channel.exchange(HASH_EXCHANGE, type: "x-consistent-hash", durable: true)
+  end
+
+  def declare_dead_letter_queues
+    exchange = channel.exchange(DEAD_LETTER_EXCHANGE, type: :topic, durable: true)
+
+    DEAD_LETTER_ROUTING_KEYS.each do |routing_key|
+      queue = channel.queue(routing_key, durable: true, arguments: dead_letter_queue_arguments)
+      queue.bind(exchange, routing_key: routing_key)
+    end
+  end
+
+  def declare_retry_queues
+    exchange = channel.exchange(RETRY_EXCHANGE, type: :topic, durable: true)
+
+    RETRY_DELAYS.each do |suffix, ttl|
+      routing_key = "billing.retry.#{suffix}"
+      queue = channel.queue(routing_key, durable: true, arguments: retry_queue_arguments(ttl))
+      queue.bind(exchange, routing_key: routing_key)
+    end
+  end
+
+  def declare_consistent_hash_shards
+    exchange = channel.exchange(HASH_EXCHANGE, type: "x-consistent-hash", durable: true)
+
+    SHARD_COUNT.times do |index|
+      queue = channel.queue("billing.subscription_shard.#{index}", durable: true, arguments: shard_queue_arguments)
+      queue.bind(exchange, routing_key: "1")
+    end
+  end
+
+  def dead_letter_queue_arguments
+    { "x-queue-type"             => "quorum",
+      "x-single-active-consumer" => true }
+  end
+
+  def retry_queue_arguments(ttl)
+    { "x-queue-type"             => "quorum",
+      "x-single-active-consumer" => true,
+      "x-message-ttl"            => ttl,
+      "x-dead-letter-exchange"   => MAIN_EXCHANGE,
+      "x-dead-letter-routing-key" => "billing.attempt.retry" }
+  end
+
+  def shard_queue_arguments
+    { "x-queue-type"             => "quorum",
+      "x-single-active-consumer" => true,
+      "x-dead-letter-exchange"   => DEAD_LETTER_EXCHANGE }
+  end
+end

--- a/spec/consumers/billing_processor_consumer_spec.rb
+++ b/spec/consumers/billing_processor_consumer_spec.rb
@@ -1,12 +1,86 @@
+# rubocop:disable RSpec/MultipleExpectations
 require "rails_helper"
 
 RSpec.describe BillingProcessorConsumer, type: :consumer do
   describe "#find_payment_attempt" do
     let(:payment_attempt) { FactoryBot.create(:payment_attempt) }
-    let(:message) { instance_double(Hutch::Message, body: { payment_attempt_id: payment_attempt.id }) }
+    let(:message) do
+      instance_double(Hutch::Message,
+                      body:       { payment_attempt_id: payment_attempt.id },
+                      message_id: SecureRandom.uuid)
+    end
 
     it "finds the payment attempt from the message payload" do
       expect(described_class.new.send(:find_payment_attempt, message)).to eq(payment_attempt)
+    end
+  end
+
+  describe "#process" do
+    let(:message) do
+      instance_double(Hutch::Message,
+                      body:       { payment_attempt_id: payment_attempt.id },
+                      message_id: SecureRandom.uuid)
+    end
+
+    context "with an active subscription and scheduled payment attempt" do
+      let(:payment_attempt) { FactoryBot.create(:payment_attempt, :scheduled, amount_attempted_cents: 500) }
+
+      it "processes the payment attempt and records a success outbox message" do
+        described_class.new.process(message)
+
+        expect(payment_attempt.reload).to be_completed
+        expect(OutboxMessage.last.topic).to eq("billing.payment.full.success")
+      end
+    end
+
+    context "with a paused subscription" do
+      let(:subscription) { FactoryBot.create(:subscription, :paused) }
+      let(:invoice) { FactoryBot.create(:invoice, subscription: subscription) }
+      let(:payment_attempt) { FactoryBot.create(:payment_attempt, :scheduled, invoice: invoice) }
+
+      it "does not process the payment attempt and records a skipped event" do
+        described_class.new.process(message)
+
+        outbox_message = OutboxMessage.find_by!(topic: "billing.payment.skipped")
+        expect(payment_attempt.reload).to be_scheduled
+        expect(outbox_message.payload["skipped_reason"]).to eq("subscription_not_active")
+      end
+    end
+
+    context "with a pending payment attempt" do
+      let(:payment_attempt) { FactoryBot.create(:payment_attempt) }
+
+      it "records a skipped event" do
+        described_class.new.process(message)
+
+        outbox_message = OutboxMessage.find_by!(topic: "billing.payment.skipped")
+        expect(outbox_message.payload["skipped_reason"]).to eq("not_scheduled")
+      end
+    end
+
+    context "with insufficient funds" do
+      let(:payment_attempt) { FactoryBot.create(:payment_attempt, :scheduled, amount_attempted_cents: 1500) }
+
+      it "records a failed payment event without raising" do
+        described_class.new.process(message)
+
+        outbox_message = OutboxMessage.find_by!(topic: "billing.payment.failed")
+        expect(payment_attempt.reload).to be_failed
+        expect(outbox_message.payload["failure_reason"]).to eq("insufficient_funds")
+      end
+    end
+
+    context "with a retryable system error" do
+      let(:payment_attempt) { FactoryBot.create(:payment_attempt, :scheduled, amount_attempted_cents: 0) }
+
+      it "records a failed payment event and raises for broker retry/dead-letter handling" do
+        expect {
+          described_class.new.process(message)
+        }.to raise_error(BillingProcessorConsumer::PaymentProcessingRetryableError)
+
+        outbox_message = OutboxMessage.find_by!(topic: "billing.payment.failed")
+        expect(outbox_message.payload["failure_reason"]).to eq("system_error")
+      end
     end
   end
 end

--- a/spec/consumers/consumer_idempotency_spec.rb
+++ b/spec/consumers/consumer_idempotency_spec.rb
@@ -1,0 +1,61 @@
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+require "rails_helper"
+
+RSpec.describe ConsumerIdempotency do
+  subject(:consumer) { consumer_class.new }
+
+  let(:consumer_class) do
+    Class.new do
+      include ConsumerIdempotency
+
+      attr_reader :processed_count
+
+      def self.name = "TestConsumer"
+
+      def initialize
+        @processed_count = 0
+      end
+
+      def process(message)
+        process_once(message) { @processed_count += 1 }
+      end
+
+      def logger = Rails.logger
+    end
+  end
+
+  let(:message) { instance_double(Hutch::Message, body: { event: "test" }, message_id: "message-1") }
+
+  it "processes a message once" do
+    consumer.process(message)
+
+    expect(consumer.processed_count).to eq(1)
+    expect(ProcessedMessage.exists?(consumer_name: "TestConsumer", message_id: "message-1")).to be(true)
+  end
+
+  it "skips duplicate messages" do
+    consumer.process(message)
+    consumer.process(message)
+
+    expect(consumer.processed_count).to eq(1)
+  end
+
+  it "releases the idempotency claim when processing fails" do
+    failing_consumer = Class.new(consumer_class) do
+      def process(message)
+        process_once(message) { raise "boom" }
+      end
+    end.new
+
+    expect { failing_consumer.process(message) }.to raise_error(RuntimeError, "boom")
+    expect(ProcessedMessage.exists?(consumer_name: "TestConsumer", message_id: "message-1")).to be(false)
+  end
+
+  it "falls back to a body digest when message_id is missing" do
+    message_without_id = instance_double(Hutch::Message, body: { event: "test" }, message_id: nil)
+
+    consumer.process(message_without_id)
+
+    expect(ProcessedMessage.last.message_id).to eq(Digest::SHA256.hexdigest("TestConsumer:{\"event\":\"test\"}"))
+  end
+end

--- a/spec/consumers/invoice_consumer_spec.rb
+++ b/spec/consumers/invoice_consumer_spec.rb
@@ -1,16 +1,21 @@
+# rubocop:disable RSpec/MultipleExpectations
 require "rails_helper"
 
 RSpec.describe InvoiceConsumer, type: :consumer do
   describe "#process" do
-    before do
-      allow(Hutch).to receive(:publish)
-    end
-
     context "with draft Invoice" do
       let(:drafted_invoice) { FactoryBot.create(:invoice) }
-      let(:message) { instance_double(Hutch::Message, body: { invoice_id: drafted_invoice.id }) }
+      let(:message) do
+        instance_double(Hutch::Message,
+                        body:       { invoice_id: drafted_invoice.id },
+                        message_id: SecureRandom.uuid)
+      end
       let(:payment_attempt) { drafted_invoice.payment_attempts.first }
-      let(:expected_payload) { { payment_attempt_id: payment_attempt.id } }
+      let(:expected_payload) do
+        { payment_attempt_id:         payment_attempt.id,
+          subscription_id:            drafted_invoice.subscription_id,
+          subscription_state_version: drafted_invoice.subscription.state_version }
+      end
 
       it "opens the invoice" do
         described_class.new.process(message)
@@ -24,10 +29,20 @@ RSpec.describe InvoiceConsumer, type: :consumer do
         expect(drafted_invoice.payment_attempts.first).to be_scheduled
       end
 
-      it "publishes the created payment attempt for processing" do
+      it "records an outbox message for processing the payment attempt" do
         described_class.new.process(message)
 
-        expect(Hutch).to have_received(:publish).with("billing.attempt.new", expected_payload)
+        outbox_message = OutboxMessage.find_by!(topic: "billing.attempt.new")
+        expect(outbox_message.payload).to eq(expected_payload.stringify_keys)
+      end
+
+      it "does not open invoices for paused subscriptions" do
+        drafted_invoice.subscription.pause!("customer requested pause")
+
+        described_class.new.process(message)
+
+        expect(drafted_invoice.reload).to be_draft
+        expect(OutboxMessage.where(topic: "billing.attempt.new")).to be_empty
       end
     end
   end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -29,6 +29,30 @@ FactoryBot.define do
     current_period_start { Time.current.beginning_of_month }
     current_period_end { Time.current.end_of_month  }
 
+    trait :active do
+      after(:build) do |subscription|
+        subscription[:status] = :active
+      end
+    end
+
+    trait :paused do
+      paused_at { Time.current }
+      pause_reason { "customer requested pause" }
+
+      after(:build) do |subscription|
+        subscription[:status] = :paused
+      end
+    end
+
+    trait :cancelled do
+      cancelled_at { Time.current }
+      cancellation_reason { "customer requested cancellation" }
+
+      after(:build) do |subscription|
+        subscription[:status] = :cancelled
+      end
+    end
+
     customer
   end
 

--- a/spec/lib/rabbit_mq_topology_spec.rb
+++ b/spec/lib/rabbit_mq_topology_spec.rb
@@ -1,0 +1,48 @@
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/VerifiedDoubles
+require "rails_helper"
+
+RSpec.describe RabbitMqTopology do
+  describe "#declare!" do
+    let(:channel) { double("Channel") }
+    let(:exchange) { double("Exchange") }
+    let(:queue) { double("Queue", bind: true) }
+
+    before do
+      allow(channel).to receive_messages(exchange: exchange, queue: queue)
+    end
+
+    it "declares exchanges, retry queues, dead-letter queues, and hash shards" do
+      described_class.new(channel).declare!
+
+      expect(channel).to have_received(:exchange).with(described_class::MAIN_EXCHANGE, type: :topic, durable: true).at_least(:once)
+      expect(channel).to have_received(:exchange).with(described_class::DEAD_LETTER_EXCHANGE, type: :topic, durable: true).at_least(:once)
+      expect(channel).to have_received(:exchange).with(described_class::RETRY_EXCHANGE, type: :topic, durable: true).at_least(:once)
+      expect(channel).to have_received(:exchange).with(described_class::HASH_EXCHANGE, type: "x-consistent-hash", durable: true).at_least(:once)
+      expect(channel).to have_received(:queue).at_least(:once)
+      expect(queue).to have_received(:bind).at_least(:once)
+    end
+  end
+
+  describe ".publish_to_consistent_hash" do
+    let(:channel) { double("Channel") }
+    let(:broker) { double("Broker", channel: channel) }
+    let(:exchange) { double("Exchange", publish: true) }
+
+    before do
+      allow(Hutch).to receive(:broker).and_return(broker)
+      allow(channel).to receive(:exchange).and_return(exchange)
+    end
+
+    it "publishes a persistent JSON message using subscription_id as routing key" do
+      described_class.publish_to_consistent_hash(topic:           "subscription.paused",
+                                                 payload:          { subscription_id: "sub-1" },
+                                                 subscription_id:  "sub-1",
+                                                 message_id:       "message-1")
+
+      expect(exchange).to have_received(:publish).with(
+        { subscription_id: "sub-1" }.to_json,
+        hash_including(routing_key: "sub-1", persistent: true, message_id: "message-1")
+      )
+    end
+  end
+end

--- a/spec/models/outbox_message_spec.rb
+++ b/spec/models/outbox_message_spec.rb
@@ -1,0 +1,41 @@
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+require "rails_helper"
+
+RSpec.describe OutboxMessage, type: :model do
+  describe ".unpublished" do
+    it "returns messages that have not been published" do
+      unpublished = described_class.create!(topic: "subscription.paused", payload: { event: "test" })
+      described_class.create!(topic: "subscription.resumed", payload: { event: "test" }, published_at: Time.current)
+
+      expect(described_class.unpublished).to contain_exactly(unpublished)
+    end
+  end
+
+  describe ".claimable" do
+    it "returns unlocked and stale locked unpublished messages" do
+      unlocked = described_class.create!(topic: "subscription.paused", payload: { event: "test" })
+      stale_locked = described_class.create!(topic: "subscription.resumed", payload: { event: "test" }, locked_at: 1.hour.ago)
+      described_class.create!(topic: "subscription.cancelled", payload: { event: "test" }, locked_at: Time.current)
+
+      expect(described_class.claimable(15.minutes.ago)).to contain_exactly(unlocked, stale_locked)
+    end
+  end
+
+  describe ".enqueue!" do
+    it "creates an unpublished outbox message for an aggregate" do
+      subscription = FactoryBot.create(:subscription)
+
+      message = described_class.enqueue!(topic:             "subscription.paused",
+                                         payload:           subscription.lifecycle_payload(reason: "pause"),
+                                         aggregate:         subscription,
+                                         aggregate_version: subscription.state_version)
+
+      expect(message).to be_persisted
+      expect(message.topic).to eq("subscription.paused")
+      expect(message.aggregate_type).to eq("Subscription")
+      expect(message.aggregate_id).to eq(subscription.id)
+      expect(message.aggregate_version).to eq(subscription.state_version)
+      expect(message.published_at).to be_nil
+    end
+  end
+end

--- a/spec/models/processed_message_spec.rb
+++ b/spec/models/processed_message_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ProcessedMessage, type: :model do
+  describe "deduplication" do
+    it "does not allow the same consumer to process the same message twice" do
+      described_class.create!(consumer_name: "Consumer", message_id: "message-1")
+
+      expect {
+        described_class.create!(consumer_name: "Consumer", message_id: "message-1")
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "allows different consumers to process the same message" do
+      described_class.create!(consumer_name: "ConsumerA", message_id: "message-1")
+
+      message = described_class.new(consumer_name: "ConsumerB", message_id: "message-1")
+
+      expect(message).to be_valid
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
 # == Schema Information
 #
 # Table name: subscriptions
@@ -9,6 +10,11 @@
 #  cancelled_at         :datetime
 #  current_period_end   :datetime         not null
 #  current_period_start :datetime         not null
+#  pause_reason         :text
+#  paused_at            :datetime
+#  resume_reason        :text
+#  resumed_at           :datetime
+#  state_version        :integer          default(0), not null
 #  status               :enum             default(NULL), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
@@ -27,4 +33,114 @@ require "rails_helper"
 
 RSpec.describe Subscription, type: :model do
   it { is_expected.to belong_to(:customer) }
+
+  describe "state machine" do
+    it "starts active" do
+      subscription = FactoryBot.create(:subscription)
+
+      expect(subscription).to be_active
+    end
+
+    it "pauses an active subscription" do
+      subscription = FactoryBot.create(:subscription)
+
+      subscription.pause!("customer requested pause")
+
+      expect(subscription).to be_paused
+    end
+
+    it "resumes a paused subscription" do
+      subscription = FactoryBot.create(:subscription, :paused)
+
+      subscription.resume!("customer requested resume")
+
+      expect(subscription).to be_active
+    end
+
+    it "cancels an active subscription" do
+      subscription = FactoryBot.create(:subscription)
+
+      subscription.cancel!("customer requested cancellation")
+
+      expect(subscription).to be_cancelled
+    end
+
+    it "cancels a paused subscription" do
+      subscription = FactoryBot.create(:subscription, :paused)
+
+      subscription.cancel!("customer requested cancellation")
+
+      expect(subscription).to be_cancelled
+    end
+
+    it "does not resume a cancelled subscription" do
+      subscription = FactoryBot.create(:subscription, :cancelled)
+
+      expect { subscription.resume! }.to raise_error(AASM::InvalidTransition)
+    end
+  end
+
+  describe "pause metadata" do
+    it "sets paused metadata and increments the state version" do
+      subscription = FactoryBot.create(:subscription)
+
+      expect {
+        subscription.pause!("customer requested pause")
+      }.to change(subscription, :state_version).by(1)
+
+      expect(subscription.paused_at).to be_present
+      expect(subscription.pause_reason).to eq("customer requested pause")
+    end
+  end
+
+  describe "resume metadata" do
+    it "sets resume metadata and extends the current period by the pause duration" do
+      now = Time.current
+      paused_at = 2.days.ago
+      current_period_end = 1.week.from_now
+      subscription = FactoryBot.create(:subscription, :paused,
+                                       paused_at:          paused_at,
+                                       current_period_end: current_period_end)
+
+      allow(Time).to receive(:current).and_return(now)
+
+      expect {
+        subscription.resume!("customer requested resume")
+      }.to change(subscription, :state_version).by(1)
+
+      expect(subscription.active_at).to be_within(1.second).of(now)
+      expect(subscription.resumed_at).to be_within(1.second).of(now)
+      expect(subscription.resume_reason).to eq("customer requested resume")
+      expect(subscription.current_period_end.to_i).to eq((current_period_end + (now - paused_at)).to_i)
+    end
+  end
+
+  describe "cancellation metadata" do
+    it "sets cancellation metadata and increments the state version" do
+      subscription = FactoryBot.create(:subscription)
+
+      expect {
+        subscription.cancel!("customer requested cancellation")
+      }.to change(subscription, :state_version).by(1)
+
+      expect(subscription.cancelled_at).to be_present
+      expect(subscription.cancellation_reason).to eq("customer requested cancellation")
+    end
+  end
+
+  describe "domain state predicates" do
+    it "is billable and service-accessible only while active" do
+      active_subscription = FactoryBot.build(:subscription)
+      paused_subscription = FactoryBot.build(:subscription, :paused)
+      cancelled_subscription = FactoryBot.build(:subscription, :cancelled)
+
+      expect(active_subscription).to be_billable
+      expect(active_subscription).to be_service_accessible
+      expect(paused_subscription).not_to be_billable
+      expect(paused_subscription).not_to be_service_accessible
+      expect(cancelled_subscription).not_to be_billable
+      expect(cancelled_subscription).not_to be_service_accessible
+      expect(cancelled_subscription).to be_terminal
+    end
+  end
 end

--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -1,21 +1,20 @@
+# rubocop:disable RSpec/MultipleExpectations
 require "rails_helper"
 
 RSpec.describe BillingService, type: :service do
   describe ".call" do
     let(:payment_attempt) { FactoryBot.create(:payment_attempt) }
     let(:payload) do
-      { payment_attempt_id: payment_attempt.id,
-        subscription_id:    payment_attempt.subscription.id }
+      { payment_attempt_id:         payment_attempt.id,
+        subscription_id:            payment_attempt.subscription.id,
+        subscription_state_version: payment_attempt.subscription.state_version }
     end
 
-    before do
-      allow(Hutch).to receive(:publish)
-    end
-
-    it "publishes the payment attempt payload expected by billing consumers" do
+    it "records the payment attempt payload expected by billing consumers" do
       described_class.call(payment_attempt)
 
-      expect(Hutch).to have_received(:publish).with("billing.attempt.new", payload)
+      outbox_message = OutboxMessage.find_by!(topic: "billing.attempt.new")
+      expect(outbox_message.payload).to eq(payload.stringify_keys)
     end
   end
 end

--- a/spec/services/cancel_subscription_service_spec.rb
+++ b/spec/services/cancel_subscription_service_spec.rb
@@ -1,0 +1,34 @@
+# rubocop:disable RSpec/MultipleExpectations
+require "rails_helper"
+
+RSpec.describe CancelSubscriptionService, type: :service do
+  describe ".call" do
+    it "cancels an active subscription" do
+      subscription = FactoryBot.create(:subscription)
+
+      result = described_class.call(subscription, reason: "customer requested cancellation")
+
+      expect(result).to be_success
+      expect(subscription.reload).to be_cancelled
+      expect(subscription.cancellation_reason).to eq("customer requested cancellation")
+    end
+
+    it "cancels a paused subscription" do
+      subscription = FactoryBot.create(:subscription, :paused)
+
+      result = described_class.call(subscription, reason: "customer requested cancellation")
+
+      expect(result).to be_success
+      expect(subscription.reload).to be_cancelled
+    end
+
+    it "is idempotent when the subscription is already cancelled" do
+      subscription = FactoryBot.create(:subscription, :cancelled)
+
+      result = described_class.call(subscription, reason: "duplicate cancellation")
+
+      expect(result).to be_success
+      expect(subscription.reload.cancellation_reason).to eq("customer requested cancellation")
+    end
+  end
+end

--- a/spec/services/outbox_publisher_service_spec.rb
+++ b/spec/services/outbox_publisher_service_spec.rb
@@ -1,0 +1,62 @@
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+require "rails_helper"
+
+RSpec.describe OutboxPublisherService, type: :service do
+  describe ".call" do
+    let(:payload) { { subscription_id: SecureRandom.uuid, event: "test" } }
+    let(:outbox_message) { OutboxMessage.create!(topic: "subscription.paused", payload: payload) }
+
+    before do
+      OutboxMessage.delete_all
+      outbox_message
+      allow(Hutch).to receive(:publish)
+      allow(RabbitMqTopology).to receive(:publish_to_consistent_hash)
+    end
+
+    it "publishes unpublished messages and marks them published" do
+      described_class.call(batch_size: 1)
+
+      expect(Hutch).to have_received(:publish).with("subscription.paused", payload.stringify_keys, { message_id: outbox_message.id })
+      expect(RabbitMqTopology).to have_received(:publish_to_consistent_hash)
+      expect(outbox_message.reload.published_at).to be_present
+      expect(outbox_message.locked_at).to be_nil
+      expect(outbox_message.attempts).to eq(1)
+    end
+
+    it "records publish failures and leaves the message unpublished" do
+      allow(Hutch).to receive(:publish).and_raise(Hutch::ConnectionError)
+
+      described_class.call(batch_size: 1)
+
+      expect(outbox_message.reload.published_at).to be_nil
+      expect(outbox_message.locked_at).to be_nil
+      expect(outbox_message.attempts).to eq(1)
+      expect(outbox_message.last_error).to be_present
+    end
+
+    it "treats consistent-hash mirror failures as best effort" do
+      allow(RabbitMqTopology).to receive(:publish_to_consistent_hash).and_raise(StandardError, "mirror unavailable")
+
+      described_class.call(batch_size: 1)
+
+      expect(outbox_message.reload.published_at).to be_present
+      expect(outbox_message.last_error).to be_nil
+    end
+
+    it "does not publish recently locked messages" do
+      outbox_message.update!(locked_at: Time.current)
+
+      described_class.call(batch_size: 1)
+
+      expect(Hutch).not_to have_received(:publish)
+    end
+
+    it "reclaims stale locked messages" do
+      outbox_message.update!(locked_at: 1.hour.ago)
+
+      described_class.call(batch_size: 1)
+
+      expect(Hutch).to have_received(:publish)
+    end
+  end
+end

--- a/spec/services/pause_subscription_service_spec.rb
+++ b/spec/services/pause_subscription_service_spec.rb
@@ -1,0 +1,52 @@
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+require "rails_helper"
+
+RSpec.describe PauseSubscriptionService, type: :service do
+  describe ".call" do
+    it "pauses an active subscription and records a versioned outbox event" do
+      subscription = FactoryBot.create(:subscription)
+
+      result = described_class.call(subscription, reason: "customer requested pause")
+      outbox_message = OutboxMessage.find_by!(topic: "subscription.paused")
+
+      expect(result).to be_success
+      expect(subscription.reload).to be_paused
+      expect(subscription.pause_reason).to eq("customer requested pause")
+      expect(outbox_message.payload["state_version"]).to eq(subscription.state_version)
+    end
+
+    it "is idempotent when the subscription is already paused" do
+      subscription = FactoryBot.create(:subscription, :paused)
+      original_paused_at = subscription.paused_at
+      original_state_version = subscription.state_version
+
+      result = described_class.call(subscription, reason: "duplicate pause")
+
+      expect(result).to be_success
+      expect(subscription.reload.pause_reason).to eq("customer requested pause")
+      expect(subscription.paused_at).to eq(original_paused_at)
+      expect(subscription.state_version).to eq(original_state_version)
+    end
+
+    it "rejects cancelled subscriptions" do
+      subscription = FactoryBot.create(:subscription, :cancelled)
+
+      result = described_class.call(subscription, reason: "too late")
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:already_cancelled)
+    end
+
+    it "removes unstarted current-period draft invoices" do
+      subscription = FactoryBot.create(:subscription)
+      invoice = FactoryBot.create(:invoice,
+                                  subscription:         subscription,
+                                  billing_period_start: subscription.current_period_start,
+                                  billing_period_end:   subscription.current_period_end)
+
+      described_class.call(subscription, reason: "customer requested pause")
+
+      expect(Invoice.exists?(invoice.id)).to be(false)
+    end
+  end
+end

--- a/spec/services/process_payment_service_spec.rb
+++ b/spec/services/process_payment_service_spec.rb
@@ -2,17 +2,12 @@ require 'rails_helper'
 require 'payment_gateway_api_mock'
 
 RSpec.describe ProcessPaymentService, type: :service do
-  # disable transaction nesting so that isolation level can be set in implementation
-  before do
-    allow(ActiveRecord::Base).to receive(:transaction).and_yield
-  end
-
   context "with PaymentAttempt be already in processing" do
-    let(:payment_attempt) { FactoryBot.build(:payment_attempt, :processing) }
+    let(:payment_attempt) { FactoryBot.create(:payment_attempt, :processing) }
     let(:payment_gateway) { PaymentGatewayApiMock.new }
 
     before do
-      payment_attempt.status = :processing
+      payment_attempt.update!(status: :processing)
     end
 
     it "returns a Failure result monad" do
@@ -32,8 +27,7 @@ RSpec.describe ProcessPaymentService, type: :service do
 
     context "with Payment Gateway returning `success`" do
       before do
-        payment_attempt.status = :scheduled
-        payment_attempt.amount_attempted_cents = 500
+        payment_attempt.update!(status: :scheduled, amount_attempted_cents: 500)
       end
 
       it "returns Success result monad" do
@@ -54,8 +48,7 @@ RSpec.describe ProcessPaymentService, type: :service do
 
     context "with Payment Gateway returning `insufficient_funds`" do
       before do
-        payment_attempt.status = :scheduled
-        payment_attempt.amount_attempted_cents = 1500
+        payment_attempt.update!(status: :scheduled, amount_attempted_cents: 1500)
       end
 
       it "returns Failure[:insufficient_funds] result monad" do
@@ -81,8 +74,7 @@ RSpec.describe ProcessPaymentService, type: :service do
 
     context "with Payment Gateway returning `system_error`" do
       before do
-        payment_attempt.status = :scheduled
-        payment_attempt.amount_attempted_cents = 0
+        payment_attempt.update!(status: :scheduled, amount_attempted_cents: 0)
       end
 
       it "return Failure[:system_error] result monad" do
@@ -108,8 +100,7 @@ RSpec.describe ProcessPaymentService, type: :service do
 
     context "with Payment Gateway returning `failed`" do
       before do
-        payment_attempt.status = :scheduled
-        payment_attempt.amount_attempted_cents = 35_000
+        payment_attempt.update!(status: :scheduled, amount_attempted_cents: 35_000)
       end
 
       it "returns Failure[:gateway_error] result monad" do
@@ -130,6 +121,25 @@ RSpec.describe ProcessPaymentService, type: :service do
       it "sets the payment attempt status to failed" do
         result = described_class.call(payment_attempt, payment_gateway)
         expect(result.failure.last.status).to eq("failed")
+      end
+    end
+
+    context "with Payment Gateway raising an exception" do
+      let(:payment_gateway) { instance_double(PaymentGatewayApiMock, charge: nil) }
+
+      before do
+        payment_attempt.update!(status: :scheduled, amount_attempted_cents: 500)
+        allow(payment_gateway).to receive(:charge).and_raise(StandardError, "network timeout")
+      end
+
+      it "returns :system_error as the failure reason" do
+        result = described_class.call(payment_attempt, payment_gateway)
+        expect(result.failure.first).to eq :system_error
+      end
+
+      it "marks the payment attempt as failed" do
+        result = described_class.call(payment_attempt, payment_gateway)
+        expect(result.failure.last.failed?).to be(true)
       end
     end
   end

--- a/spec/services/resume_subscription_service_spec.rb
+++ b/spec/services/resume_subscription_service_spec.rb
@@ -1,0 +1,62 @@
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+require "rails_helper"
+
+RSpec.describe ResumeSubscriptionService, type: :service do
+  describe ".call" do
+    it "resumes a paused subscription" do
+      subscription = FactoryBot.create(:subscription, :paused)
+
+      result = described_class.call(subscription, reason: "customer requested resume")
+
+      expect(result).to be_success
+      expect(subscription.reload).to be_active
+      expect(subscription.resume_reason).to eq("customer requested resume")
+    end
+
+    it "extends the current period by the pause duration" do
+      now = Time.current
+      paused_at = 2.days.ago
+      current_period_end = 1.week.from_now
+      subscription = FactoryBot.create(:subscription, :paused,
+                                       paused_at:          paused_at,
+                                       current_period_end: current_period_end)
+
+      allow(Time).to receive(:current).and_return(now)
+
+      described_class.call(subscription, reason: "customer requested resume")
+
+      expect(subscription.reload.current_period_end.to_i).to eq((current_period_end + (now - paused_at)).to_i)
+      expect(subscription.active_at).to be_within(1.second).of(now)
+    end
+
+    it "re-enqueues scheduled payment attempts" do
+      subscription = FactoryBot.create(:subscription, :paused)
+      invoice = FactoryBot.create(:invoice, subscription: subscription)
+      payment_attempt = FactoryBot.create(:payment_attempt, :scheduled, invoice: invoice)
+
+      described_class.call(subscription, reason: "customer requested resume")
+
+      outbox_message = OutboxMessage.find_by!(topic: "billing.attempt.new")
+      expect(outbox_message.payload["payment_attempt_id"]).to eq(payment_attempt.id)
+      expect(outbox_message.payload["subscription_state_version"]).to eq(subscription.reload.state_version)
+    end
+
+    it "is idempotent when the subscription is already active" do
+      subscription = FactoryBot.create(:subscription)
+
+      result = described_class.call(subscription, reason: "duplicate resume")
+
+      expect(result).to be_success
+      expect(subscription.reload.resume_reason).to be_nil
+    end
+
+    it "rejects cancelled subscriptions" do
+      subscription = FactoryBot.create(:subscription, :cancelled)
+
+      result = described_class.call(subscription, reason: "too late")
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:already_cancelled)
+    end
+  end
+end


### PR DESCRIPTION
Add paused/resumed subscription state handling with row-locked lifecycle services, state versioning, service-access semantics, and billing-period extension on resume.

Introduce outbox/inbox tables, idempotent consumers, resilient outbox publishing, and RabbitMQ topology for durable quorum queues, DLX/retry routing, and subscription hash mirroring.

Guard billing consumers against stale/out-of-order messages and add coverage for failure, skip, duplicate, retryable, and outbox edge cases.

Entire-Checkpoint: 5d7b15c6144b