### PR TITLE
feat: validate service command inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GuilefulCharger
 
-GuilefulCharger is a Rails API application that sketches a subscription billing workflow using PostgreSQL, RabbitMQ/Hutch, AASM state machines, dry-validation contracts, and MoneyRails. The current codebase is best treated as a prototype: the core database tables and first-pass payment-processing objects exist, while retries, partial rebilling, payment-method management, audit logging, and production delivery guarantees are not complete.
+GuilefulCharger is a Rails API application that sketches a subscription billing workflow using PostgreSQL, RabbitMQ/Hutch, AASM state machines, dry-validation contracts/command schemas, and MoneyRails. The current codebase is best treated as a prototype: the core database tables and first-pass payment-processing objects exist, while retries, partial rebilling, payment-method management, audit logging, and production delivery guarantees are not complete.
 
 ## Current Implementation
 
@@ -12,6 +12,7 @@ GuilefulCharger is a Rails API application that sketches a subscription billing 
 - MoneyRails for cent-based monetary columns.
 - AASM for model state machines.
 - dry-validation for message payload contracts declared through the `ActiveConsumer.message_schema` DSL at consumer boundaries.
+- dry-validation for service command input schemas; declared keys are strictly validated and undeclared keyword arguments are preserved for `Dry::Initializer` options rather than silently dropped.
 - `ActiveConsumer.consumer_options` DSL for Hutch quorum queue, dead-letter, delivery-limit, and single-active-consumer queue settings.
 - RSpec test suite with FactoryBot.
 
@@ -57,6 +58,7 @@ Implemented behavior:
 - Supports `active -> paused -> active`, `active -> cancelled`, and `paused -> cancelled` lifecycle transitions.
 - Active subscriptions are billable and service-accessible.
 - Paused subscriptions are not billable and not service-accessible.
+- Pause/resume/cancel command services validate keyword input with `ApplicationService.input_schema` and return structured `Failure[:code, metadata]` results for non-happy paths.
 - Resuming a paused subscription refreshes `active_at`, extends `current_period_end` by the pause duration, and re-enqueues existing scheduled payment attempts.
 - Cancelled subscriptions are terminal.
 - Can issue a draft invoice for its current billing period via `issue_new_invoice!`.
@@ -151,6 +153,7 @@ The intended flow in the current code is:
    - Calls a gateway object that responds to `#charge`.
    - Marks the attempt `completed` for gateway success.
    - Marks the attempt `failed` for insufficient funds, gateway failures, or mapped system errors.
+   - Returns structured `Failure[:code, metadata]` results that include payment-attempt context.
 
 ## Current Gaps and Inaccurate Assumptions Found During Review
 

--- a/app/consumers/billing_processor_consumer.rb
+++ b/app/consumers/billing_processor_consumer.rb
@@ -39,8 +39,8 @@ class BillingProcessorConsumer
     when Success
       publish_payment_success(result.value!)
     when Failure
-      error_type, processed_attempt = result.failure
-      handle_payment_failure(error_type, processed_attempt)
+      error_type, metadata = result.failure
+      handle_payment_failure(error_type, metadata.fetch(:payment_attempt))
     end
   end
 

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,4 +1,60 @@
+require "dry-validation"
+
 class ApplicationService
   extend Dry::Initializer
-  def self.call(...) = new(...).call
+  extend Dry::Monads[:result]
+  include Dry::Monads[:result]
+
+  def self.call(*args, **kwargs, &block)
+    input_result = validate_input(kwargs)
+    return input_result if input_result.failure?
+
+    new(*args, **input_result.value!, &block).call
+  end
+
+  def self.input_schema(&block)
+    @input_schema_block = block
+    @input_contract = nil
+  end
+
+  def self.input_contract
+    @input_contract ||= build_input_contract
+  end
+
+  def self.validate_input(input)
+    return Success(input) unless @input_schema_block
+
+    result = input_contract.call(input)
+    return Success(input.merge(result.to_h)) if result.success?
+
+    Failure[:invalid_input, { errors: result.errors.to_h }]
+  end
+
+  def self.build_input_contract
+    schema_block = @input_schema_block
+
+    Class.new(Dry::Validation::Contract) do
+      # Use a strict schema for in-process service commands: callers should pass
+      # correctly typed Ruby values, not HTTP/message-style values that need
+      # coercion. `result.to_h` includes only declared keys, so validate_input
+      # merges validated declared values back into the original keyword hash to
+      # preserve undeclared Dry::Initializer options instead of silently dropping
+      # them.
+      schema(&schema_block)
+    end.new
+  end
+  private_class_method :build_input_contract
+
+  private
+
+  def service_failure(code, **metadata)
+    Failure[code, metadata]
+  end
+
+  def subscription_failure(code, subscription)
+    service_failure(code,
+                    subscription_id: subscription.id,
+                    status:          subscription.status,
+                    state_version:   subscription.state_version)
+  end
 end

--- a/app/services/cancel_subscription_service.rb
+++ b/app/services/cancel_subscription_service.rb
@@ -1,8 +1,10 @@
 class CancelSubscriptionService < ApplicationService
-  include Dry::Monads[:result]
-
   param :subscription
   option :reason, optional: true
+
+  input_schema do
+    optional(:reason).maybe(:string)
+  end
 
   def call
     Subscription.transaction do

--- a/app/services/pause_subscription_service.rb
+++ b/app/services/pause_subscription_service.rb
@@ -1,15 +1,17 @@
 class PauseSubscriptionService < ApplicationService
-  include Dry::Monads[:result]
-
   param :subscription
   option :reason, optional: true
+
+  input_schema do
+    optional(:reason).maybe(:string)
+  end
 
   def call
     Subscription.transaction do
       subscription.lock!
 
       return Success(subscription) if subscription.paused?
-      return Failure[:already_cancelled, subscription] if subscription.cancelled?
+      return subscription_failure(:already_cancelled, subscription) if subscription.cancelled?
 
       subscription.pause!(reason)
       destroy_unstarted_current_period_draft_invoices

--- a/app/services/process_payment_service.rb
+++ b/app/services/process_payment_service.rb
@@ -1,6 +1,4 @@
 class ProcessPaymentService < ApplicationService
-  include Dry::Monads[:result]
-
   SystemErrorResponse = Struct.new(:status, :transaction_id, :message, keyword_init: true) do
     def to_h
       { status:         status,
@@ -13,7 +11,7 @@ class ProcessPaymentService < ApplicationService
   param :payment_gateway
 
   def call
-    return Failure[:already_in_processing, payment_attempt] if payment_attempt.processing?
+    return payment_attempt_failure(:already_in_processing) if payment_attempt.processing?
 
     claim_result = claim_payment_attempt
     return claim_result if claim_result.failure?
@@ -47,9 +45,9 @@ class ProcessPaymentService < ApplicationService
   end
 
   def validate_claimable_payment_attempt
-    return Failure[:already_in_processing, payment_attempt] if payment_attempt.processing?
-    return Failure[:not_scheduled, payment_attempt] unless payment_attempt.scheduled?
-    return Failure[:subscription_not_active, payment_attempt] unless payment_attempt.subscription.active?
+    return payment_attempt_failure(:already_in_processing) if payment_attempt.processing?
+    return payment_attempt_failure(:not_scheduled) unless payment_attempt.scheduled?
+    return payment_attempt_failure(:subscription_not_active) unless payment_attempt.subscription.active?
 
     Success(payment_attempt)
   end
@@ -79,22 +77,30 @@ class ProcessPaymentService < ApplicationService
 
   def handle_api_insufficient_funds
     payment_attempt.fail!(response, :insufficient_funds)
-    Failure[:insufficient_funds, payment_attempt]
+    payment_attempt_failure(:insufficient_funds)
   end
 
   def handle_api_failure
     payment_attempt.fail!(response, :gateway_error)
-    Failure[:gateway_error, payment_attempt]
+    payment_attempt_failure(:gateway_error)
   end
 
   def handle_api_system_error
     payment_attempt.fail!(response, :system_error)
-    Failure[:system_error, payment_attempt]
+    payment_attempt_failure(:system_error)
   end
 
   def handle_exception(ex)
     payment_attempt.fail!(response || system_error_response(ex), :system_error) if payment_attempt.processing?
-    Failure[:system_error, payment_attempt]
+    payment_attempt_failure(:system_error)
+  end
+
+  def payment_attempt_failure(code)
+    service_failure(code,
+                    payment_attempt:        payment_attempt,
+                    payment_attempt_id:     payment_attempt.id,
+                    payment_attempt_status: payment_attempt.status,
+                    invoice_id:             payment_attempt.invoice_id)
   end
 
   def system_error_response(ex)

--- a/app/services/resume_subscription_service.rb
+++ b/app/services/resume_subscription_service.rb
@@ -1,15 +1,17 @@
 class ResumeSubscriptionService < ApplicationService
-  include Dry::Monads[:result]
-
   param :subscription
   option :reason, optional: true
+
+  input_schema do
+    optional(:reason).maybe(:string)
+  end
 
   def call
     Subscription.transaction do
       subscription.lock!
 
       return Success(subscription) if subscription.active?
-      return Failure[:already_cancelled, subscription] if subscription.cancelled?
+      return subscription_failure(:already_cancelled, subscription) if subscription.cancelled?
 
       subscription.resume!(reason)
       enqueue_subscription_resumed

--- a/spec/services/application_service_spec.rb
+++ b/spec/services/application_service_spec.rb
@@ -1,0 +1,64 @@
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+require "rails_helper"
+
+RSpec.describe ApplicationService, type: :service do
+  describe ".input_schema" do
+    let(:subscription) { FactoryBot.create(:subscription) }
+
+    let(:service_class) do
+      Class.new(described_class) do
+        option :reason, optional: true
+        option :source, optional: true
+
+        input_schema do
+          optional(:reason).maybe(:string)
+        end
+
+        def call
+          Success(reason: reason, source: source)
+        end
+      end
+    end
+
+    it "allows valid keyword input" do
+      result = service_class.call(reason: "customer requested")
+
+      expect(result).to be_success
+      expect(result.value!).to eq(reason: "customer requested", source: nil)
+    end
+
+    it "preserves undeclared keyword input for Dry::Initializer options" do
+      result = service_class.call(reason: "customer requested", source: "admin")
+
+      expect(result).to be_success
+      expect(result.value!).to eq(reason: "customer requested", source: "admin")
+    end
+
+    it "returns a structured invalid_input failure before service execution" do
+      result = service_class.call(reason: 123)
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:invalid_input)
+      expect(result.failure.last.fetch(:errors)).to include(:reason)
+    end
+
+    it "allows positional args with no keyword input when schema fields are optional" do
+      positional_service = Class.new(described_class) do
+        param :subscription
+
+        input_schema do
+          optional(:reason).maybe(:string)
+        end
+
+        def call
+          Success(subscription)
+        end
+      end
+
+      result = positional_service.call(subscription)
+
+      expect(result).to be_success
+      expect(result.value!).to eq(subscription)
+    end
+  end
+end

--- a/spec/services/cancel_subscription_service_spec.rb
+++ b/spec/services/cancel_subscription_service_spec.rb
@@ -1,16 +1,19 @@
-# rubocop:disable RSpec/MultipleExpectations
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
 require "rails_helper"
 
 RSpec.describe CancelSubscriptionService, type: :service do
   describe ".call" do
-    it "cancels an active subscription" do
+    it "cancels an active subscription and records a versioned outbox event" do
       subscription = FactoryBot.create(:subscription)
 
       result = described_class.call(subscription, reason: "customer requested cancellation")
+      outbox_message = OutboxMessage.find_by!(topic: "subscription.cancelled")
 
       expect(result).to be_success
       expect(subscription.reload).to be_cancelled
       expect(subscription.cancellation_reason).to eq("customer requested cancellation")
+      expect(outbox_message.payload["subscription_id"]).to eq(subscription.id)
+      expect(outbox_message.payload["state_version"]).to eq(subscription.state_version)
     end
 
     it "cancels a paused subscription" do
@@ -24,11 +27,37 @@ RSpec.describe CancelSubscriptionService, type: :service do
 
     it "is idempotent when the subscription is already cancelled" do
       subscription = FactoryBot.create(:subscription, :cancelled)
+      original_state_version = subscription.state_version
 
       result = described_class.call(subscription, reason: "duplicate cancellation")
 
       expect(result).to be_success
       expect(subscription.reload.cancellation_reason).to eq("customer requested cancellation")
+      expect(subscription.state_version).to eq(original_state_version)
+    end
+
+    it "does not clean up invoices or payment attempts" do
+      subscription = FactoryBot.create(:subscription)
+      invoice = FactoryBot.create(:invoice,
+                                  subscription:         subscription,
+                                  billing_period_start: subscription.current_period_start,
+                                  billing_period_end:   subscription.current_period_end)
+      payment_attempt = FactoryBot.create(:payment_attempt, invoice: invoice)
+
+      described_class.call(subscription, reason: "customer requested cancellation")
+
+      expect(Invoice.exists?(invoice.id)).to be(true)
+      expect(PaymentAttempt.exists?(payment_attempt.id)).to be(true)
+    end
+
+    it "rejects invalid command input" do
+      subscription = FactoryBot.create(:subscription)
+
+      result = described_class.call(subscription, reason: 123)
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:invalid_input)
+      expect(result.failure.last.fetch(:errors)).to include(:reason)
     end
   end
 end

--- a/spec/services/pause_subscription_service_spec.rb
+++ b/spec/services/pause_subscription_service_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe PauseSubscriptionService, type: :service do
       expect(result).to be_success
       expect(subscription.reload).to be_paused
       expect(subscription.pause_reason).to eq("customer requested pause")
+      expect(outbox_message.topic).to eq("subscription.paused")
+      expect(outbox_message.payload["subscription_id"]).to eq(subscription.id)
       expect(outbox_message.payload["state_version"]).to eq(subscription.state_version)
     end
 
@@ -28,13 +30,24 @@ RSpec.describe PauseSubscriptionService, type: :service do
       expect(subscription.state_version).to eq(original_state_version)
     end
 
-    it "rejects cancelled subscriptions" do
+    it "rejects cancelled subscriptions with structured failure metadata" do
       subscription = FactoryBot.create(:subscription, :cancelled)
 
       result = described_class.call(subscription, reason: "too late")
 
       expect(result).to be_failure
       expect(result.failure.first).to eq(:already_cancelled)
+      expect(result.failure.last).to include(subscription_id: subscription.id, status: "cancelled")
+    end
+
+    it "rejects invalid command input" do
+      subscription = FactoryBot.create(:subscription)
+
+      result = described_class.call(subscription, reason: 123)
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:invalid_input)
+      expect(result.failure.last.fetch(:errors)).to include(:reason)
     end
 
     it "removes unstarted current-period draft invoices" do
@@ -47,6 +60,44 @@ RSpec.describe PauseSubscriptionService, type: :service do
       described_class.call(subscription, reason: "customer requested pause")
 
       expect(Invoice.exists?(invoice.id)).to be(false)
+    end
+
+    it "preserves current-period invoices that already have payment attempts" do
+      subscription = FactoryBot.create(:subscription)
+      invoice = FactoryBot.create(:invoice,
+                                  subscription:         subscription,
+                                  billing_period_start: subscription.current_period_start,
+                                  billing_period_end:   subscription.current_period_end)
+      FactoryBot.create(:payment_attempt, invoice: invoice)
+
+      described_class.call(subscription, reason: "customer requested pause")
+
+      expect(Invoice.exists?(invoice.id)).to be(true)
+    end
+
+    it "preserves draft invoices from other billing periods" do
+      subscription = FactoryBot.create(:subscription)
+      invoice = FactoryBot.create(:invoice,
+                                  subscription:         subscription,
+                                  billing_period_start: 2.months.ago.beginning_of_month,
+                                  billing_period_end:   2.months.ago.end_of_month)
+
+      described_class.call(subscription, reason: "customer requested pause")
+
+      expect(Invoice.exists?(invoice.id)).to be(true)
+    end
+
+    it "preserves non-draft invoices for the current period" do
+      subscription = FactoryBot.create(:subscription)
+      invoice = FactoryBot.create(:invoice,
+                                  subscription:         subscription,
+                                  billing_period_start: subscription.current_period_start,
+                                  billing_period_end:   subscription.current_period_end)
+      invoice.open_new!
+
+      described_class.call(subscription, reason: "customer requested pause")
+
+      expect(Invoice.exists?(invoice.id)).to be(true)
     end
   end
 end

--- a/spec/services/process_payment_service_spec.rb
+++ b/spec/services/process_payment_service_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable RSpec/MultipleExpectations
 require 'rails_helper'
 require 'payment_gateway_api_mock'
 
@@ -18,6 +19,34 @@ RSpec.describe ProcessPaymentService, type: :service do
     it "returns :already_in_processing as the failure reason" do
       result = described_class.call(payment_attempt, payment_gateway)
       expect(result.failure.first).to eq :already_in_processing
+    end
+  end
+
+  context "with PaymentAttempt not scheduled" do
+    let(:payment_attempt) { FactoryBot.create(:payment_attempt) }
+    let(:payment_gateway) { instance_double(PaymentGatewayApiMock, charge: nil) }
+
+    it "returns :not_scheduled without charging the gateway" do
+      result = described_class.call(payment_attempt, payment_gateway)
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:not_scheduled)
+      expect(payment_gateway).not_to have_received(:charge)
+    end
+  end
+
+  context "with inactive subscription" do
+    let(:subscription) { FactoryBot.create(:subscription, :paused) }
+    let(:invoice) { FactoryBot.create(:invoice, subscription: subscription) }
+    let(:payment_attempt) { FactoryBot.create(:payment_attempt, :scheduled, invoice: invoice) }
+    let(:payment_gateway) { instance_double(PaymentGatewayApiMock, charge: nil) }
+
+    it "returns :subscription_not_active without charging the gateway" do
+      result = described_class.call(payment_attempt, payment_gateway)
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:subscription_not_active)
+      expect(payment_gateway).not_to have_received(:charge)
     end
   end
 
@@ -63,12 +92,12 @@ RSpec.describe ProcessPaymentService, type: :service do
 
       it "marks the payment attempt as failed" do
         result = described_class.call(payment_attempt, payment_gateway)
-        expect(result.failure.last.failed?).to be(true)
+        expect(result.failure.last.fetch(:payment_attempt).failed?).to be(true)
       end
 
       it "sets the payment attempt status to failed" do
         result = described_class.call(payment_attempt, payment_gateway)
-        expect(result.failure.last.status).to eq("failed")
+        expect(result.failure.last.fetch(:payment_attempt).status).to eq("failed")
       end
     end
 
@@ -89,12 +118,12 @@ RSpec.describe ProcessPaymentService, type: :service do
 
       it "marks the payment attempt as failed" do
         result = described_class.call(payment_attempt, payment_gateway)
-        expect(result.failure.last.failed?).to be(true)
+        expect(result.failure.last.fetch(:payment_attempt).failed?).to be(true)
       end
 
       it "sets the payment attempt status to failed" do
         result = described_class.call(payment_attempt, payment_gateway)
-        expect(result.failure.last.status).to eq("failed")
+        expect(result.failure.last.fetch(:payment_attempt).status).to eq("failed")
       end
     end
 
@@ -115,12 +144,12 @@ RSpec.describe ProcessPaymentService, type: :service do
 
       it "marks the payment attempt as failed" do
         result = described_class.call(payment_attempt, payment_gateway)
-        expect(result.failure.last.failed?).to be(true)
+        expect(result.failure.last.fetch(:payment_attempt).failed?).to be(true)
       end
 
       it "sets the payment attempt status to failed" do
         result = described_class.call(payment_attempt, payment_gateway)
-        expect(result.failure.last.status).to eq("failed")
+        expect(result.failure.last.fetch(:payment_attempt).status).to eq("failed")
       end
     end
 
@@ -139,7 +168,22 @@ RSpec.describe ProcessPaymentService, type: :service do
 
       it "marks the payment attempt as failed" do
         result = described_class.call(payment_attempt, payment_gateway)
-        expect(result.failure.last.failed?).to be(true)
+        expect(result.failure.last.fetch(:payment_attempt).failed?).to be(true)
+      end
+    end
+
+    context "with an exception while finalizing a gateway response" do
+      before do
+        payment_attempt.update!(status: :scheduled, amount_attempted_cents: 500)
+        allow(payment_attempt).to receive(:succeed!).and_raise(StandardError, "database timeout")
+      end
+
+      it "marks the processing attempt as failed using the existing gateway response" do
+        result = described_class.call(payment_attempt, payment_gateway)
+
+        expect(result.failure.first).to eq(:system_error)
+        expect(payment_attempt.reload).to be_failed
+        expect(payment_attempt.gateway_response["status"]).to eq("success")
       end
     end
   end

--- a/spec/services/resume_subscription_service_spec.rb
+++ b/spec/services/resume_subscription_service_spec.rb
@@ -3,14 +3,17 @@ require "rails_helper"
 
 RSpec.describe ResumeSubscriptionService, type: :service do
   describe ".call" do
-    it "resumes a paused subscription" do
+    it "resumes a paused subscription and records a versioned outbox event" do
       subscription = FactoryBot.create(:subscription, :paused)
 
       result = described_class.call(subscription, reason: "customer requested resume")
+      outbox_message = OutboxMessage.find_by!(topic: "subscription.resumed")
 
       expect(result).to be_success
       expect(subscription.reload).to be_active
       expect(subscription.resume_reason).to eq("customer requested resume")
+      expect(outbox_message.payload["subscription_id"]).to eq(subscription.id)
+      expect(outbox_message.payload["state_version"]).to eq(subscription.state_version)
     end
 
     it "extends the current period by the pause duration" do
@@ -41,6 +44,26 @@ RSpec.describe ResumeSubscriptionService, type: :service do
       expect(outbox_message.payload["subscription_state_version"]).to eq(subscription.reload.state_version)
     end
 
+    it "succeeds without billing attempt events when there are no scheduled payment attempts" do
+      subscription = FactoryBot.create(:subscription, :paused)
+
+      result = described_class.call(subscription, reason: "customer requested resume")
+
+      expect(result).to be_success
+      expect(OutboxMessage.exists?(topic: "subscription.resumed")).to be(true)
+      expect(OutboxMessage.where(topic: "billing.attempt.new")).to be_empty
+    end
+
+    it "resumes without extending the period when paused_at is not recorded" do
+      current_period_end = 1.week.from_now
+      subscription = FactoryBot.create(:subscription, :paused, current_period_end: current_period_end)
+      subscription.update_column(:paused_at, nil) # rubocop:disable Rails/SkipsModelValidations
+
+      described_class.call(subscription, reason: "customer requested resume")
+
+      expect(subscription.reload.current_period_end.to_i).to eq(current_period_end.to_i)
+    end
+
     it "is idempotent when the subscription is already active" do
       subscription = FactoryBot.create(:subscription)
 
@@ -50,13 +73,24 @@ RSpec.describe ResumeSubscriptionService, type: :service do
       expect(subscription.reload.resume_reason).to be_nil
     end
 
-    it "rejects cancelled subscriptions" do
+    it "rejects cancelled subscriptions with structured failure metadata" do
       subscription = FactoryBot.create(:subscription, :cancelled)
 
       result = described_class.call(subscription, reason: "too late")
 
       expect(result).to be_failure
       expect(result.failure.first).to eq(:already_cancelled)
+      expect(result.failure.last).to include(subscription_id: subscription.id, status: "cancelled")
+    end
+
+    it "rejects invalid command input" do
+      subscription = FactoryBot.create(:subscription, :paused)
+
+      result = described_class.call(subscription, reason: 123)
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:invalid_input)
+      expect(result.failure.last.fetch(:errors)).to include(:reason)
     end
   end
 end


### PR DESCRIPTION
Add ApplicationService input_schema support backed by dry-validation while preserving undeclared Dry::Initializer keyword options.

Standardize service failures as Failure[:code, metadata] and move shared subscription failure metadata into ApplicationService.

Entire-Checkpoint: bef3ad486742