### PR TITLE
refactor: centralize service failure metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DOCKER_COMPOSE_FILE := .devcontainer/compose.yaml
 RAILS_APP_SERVICE := rails-app
 
-.PHONY: all help docker-build-test docker-compose-up-test docker-compose-down-test db-test-prepare bootstrap test test-all clean-docker-test
+.PHONY: all help docker-build-test docker-compose-up-test docker-compose-down-test db-test-prepare bootstrap test lint security-check test-all check clean-docker-test
 
 .DEFAULT_GOAL := help
 
@@ -28,8 +28,17 @@ db-test-prepare: docker-compose-up-test ## Prepare the test database inside the 
 test: db-test-prepare ## Run RSpec tests inside the Docker container. Usage: make test RSPEC_ARGS="spec/models/customer_spec.rb:123 --seed 123"
 	docker-compose -f $(DOCKER_COMPOSE_FILE) exec $(RAILS_APP_SERVICE) bin/rspec $(RSPEC_ARGS)
 
+lint: docker-compose-up-test ## Run RuboCop inside the Docker container. Usage: make lint RUBOCOP_ARGS="app/services"
+	docker-compose -f $(DOCKER_COMPOSE_FILE) exec $(RAILS_APP_SERVICE) bin/rubocop $(RUBOCOP_ARGS)
+
+security-check: docker-compose-up-test ## Run Brakeman inside the Docker container. Usage: make security-check BRAKEMAN_ARGS="--no-pager"
+	docker-compose -f $(DOCKER_COMPOSE_FILE) exec $(RAILS_APP_SERVICE) bin/brakeman $(BRAKEMAN_ARGS)
+
 test-all: docker-build-test docker-compose-up-test db-test-prepare test ## Build, setup, and run all tests
 	@echo "All tests completed successfully."
+
+check: test lint ## Run tests and linting
+	@echo "Checks completed successfully."
 
 clean-docker-test: ## Remove test Docker images and volumes
 	docker-compose -f $(DOCKER_COMPOSE_FILE) down -v --rmi all

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ GuilefulCharger is a Rails API application that sketches a subscription billing 
 - AASM for model state machines.
 - dry-validation for message payload contracts declared through the `ActiveConsumer.message_schema` DSL at consumer boundaries.
 - dry-validation for service command input schemas; declared keys are strictly validated and undeclared keyword arguments are preserved for `Dry::Initializer` options rather than silently dropped.
+- Shared `ApplicationService` result helpers for structured `Failure[:code, metadata]` values and common subscription/payment-attempt metadata.
 - `ActiveConsumer.consumer_options` DSL for Hutch quorum queue, dead-letter, delivery-limit, and single-active-consumer queue settings.
 - RSpec test suite with FactoryBot.
 
@@ -266,6 +267,20 @@ bin/rspec
 During this review, direct local `bin/rspec` could not run because required gems were not installed locally. Use `bundle install` or `make bootstrap` first.
 
 ### Linting and security scan
+
+```bash
+make lint
+make security-check
+```
+
+Pass tool-specific arguments through variables:
+
+```bash
+make lint RUBOCOP_ARGS="app/services"
+make security-check BRAKEMAN_ARGS="--no-pager"
+```
+
+Local, non-Docker equivalents are still available:
 
 ```bash
 bin/rubocop

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -47,14 +47,29 @@ class ApplicationService
 
   private
 
-  def service_failure(code, **metadata)
+  def failure_result(code, **metadata)
     Failure[code, metadata]
   end
 
-  def subscription_failure(code, subscription)
-    service_failure(code,
-                    subscription_id: subscription.id,
-                    status:          subscription.status,
-                    state_version:   subscription.state_version)
+  def subscription_metadata(subscription)
+    { subscription_id: subscription.id,
+      status:          subscription.status,
+      state_version:   subscription.state_version }
+  end
+
+  def subscription_failure(code, subscription, **metadata)
+    failure_result(code, **metadata.merge(subscription_metadata(subscription)))
+  end
+
+  def payment_attempt_metadata(payment_attempt)
+    { payment_attempt_id:     payment_attempt.id,
+      payment_attempt_status: payment_attempt.status,
+      invoice_id:             payment_attempt.invoice_id }
+  end
+
+  def payment_attempt_failure(code, payment_attempt, **metadata)
+    structured_metadata = { payment_attempt: payment_attempt }.merge(payment_attempt_metadata(payment_attempt))
+
+    failure_result(code, **metadata.merge(structured_metadata))
   end
 end

--- a/app/services/process_payment_service.rb
+++ b/app/services/process_payment_service.rb
@@ -11,7 +11,7 @@ class ProcessPaymentService < ApplicationService
   param :payment_gateway
 
   def call
-    return payment_attempt_failure(:already_in_processing) if payment_attempt.processing?
+    return payment_attempt_failure(:already_in_processing, payment_attempt) if payment_attempt.processing?
 
     claim_result = claim_payment_attempt
     return claim_result if claim_result.failure?
@@ -45,9 +45,9 @@ class ProcessPaymentService < ApplicationService
   end
 
   def validate_claimable_payment_attempt
-    return payment_attempt_failure(:already_in_processing) if payment_attempt.processing?
-    return payment_attempt_failure(:not_scheduled) unless payment_attempt.scheduled?
-    return payment_attempt_failure(:subscription_not_active) unless payment_attempt.subscription.active?
+    return payment_attempt_failure(:already_in_processing, payment_attempt) if payment_attempt.processing?
+    return payment_attempt_failure(:not_scheduled, payment_attempt) unless payment_attempt.scheduled?
+    return payment_attempt_failure(:subscription_not_active, payment_attempt) unless payment_attempt.subscription.active?
 
     Success(payment_attempt)
   end
@@ -77,30 +77,22 @@ class ProcessPaymentService < ApplicationService
 
   def handle_api_insufficient_funds
     payment_attempt.fail!(response, :insufficient_funds)
-    payment_attempt_failure(:insufficient_funds)
+    payment_attempt_failure(:insufficient_funds, payment_attempt)
   end
 
   def handle_api_failure
     payment_attempt.fail!(response, :gateway_error)
-    payment_attempt_failure(:gateway_error)
+    payment_attempt_failure(:gateway_error, payment_attempt)
   end
 
   def handle_api_system_error
     payment_attempt.fail!(response, :system_error)
-    payment_attempt_failure(:system_error)
+    payment_attempt_failure(:system_error, payment_attempt)
   end
 
   def handle_exception(ex)
     payment_attempt.fail!(response || system_error_response(ex), :system_error) if payment_attempt.processing?
-    payment_attempt_failure(:system_error)
-  end
-
-  def payment_attempt_failure(code)
-    service_failure(code,
-                    payment_attempt:        payment_attempt,
-                    payment_attempt_id:     payment_attempt.id,
-                    payment_attempt_status: payment_attempt.status,
-                    invoice_id:             payment_attempt.invoice_id)
+    payment_attempt_failure(:system_error, payment_attempt)
   end
 
   def system_error_response(ex)

--- a/spec/services/application_service_spec.rb
+++ b/spec/services/application_service_spec.rb
@@ -2,6 +2,141 @@
 require "rails_helper"
 
 RSpec.describe ApplicationService, type: :service do
+  describe "result helpers" do
+    let(:subscription) { FactoryBot.create(:subscription, :cancelled) }
+    let(:payment_attempt) { FactoryBot.create(:payment_attempt, :scheduled) }
+
+    it "builds structured failure results" do
+      service_class = Class.new(described_class) do
+        def call
+          failure_result(:example_error, detail: "test")
+        end
+      end
+
+      result = service_class.call
+
+      expect(result).to be_failure
+      expect(result.failure).to eq([ :example_error, { detail: "test" } ])
+    end
+
+    it "builds subscription metadata" do
+      service_class = Class.new(described_class) do
+        param :subscription
+
+        def call
+          Success(subscription_metadata(subscription))
+        end
+      end
+
+      result = service_class.call(subscription)
+
+      expect(result).to be_success
+      expect(result.value!).to eq(subscription_id: subscription.id,
+                                  status:          "cancelled",
+                                  state_version:   subscription.state_version)
+    end
+
+    it "builds subscription failures with extra metadata" do
+      service_class = Class.new(described_class) do
+        param :subscription
+
+        def call
+          subscription_failure(:already_cancelled, subscription, action: "pause")
+        end
+      end
+
+      result = service_class.call(subscription)
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:already_cancelled)
+      expect(result.failure.last).to include(subscription_id: subscription.id,
+                                             status:          "cancelled",
+                                             state_version:   subscription.state_version,
+                                             action:          "pause")
+    end
+
+    it "keeps structured subscription metadata when extra metadata conflicts" do
+      service_class = Class.new(described_class) do
+        param :subscription
+
+        def call
+          subscription_failure(:already_cancelled,
+                               subscription,
+                               subscription_id: "wrong",
+                               status:          "wrong",
+                               state_version:   -1)
+        end
+      end
+
+      result = service_class.call(subscription)
+
+      expect(result.failure.last).to include(subscription_id: subscription.id,
+                                             status:          "cancelled",
+                                             state_version:   subscription.state_version)
+    end
+
+    it "builds payment attempt metadata without traversing to subscription" do
+      service_class = Class.new(described_class) do
+        param :payment_attempt
+
+        def call
+          Success(payment_attempt_metadata(payment_attempt))
+        end
+      end
+
+      result = service_class.call(payment_attempt)
+
+      expect(result).to be_success
+      expect(result.value!).to eq(payment_attempt_id:     payment_attempt.id,
+                                  payment_attempt_status: "scheduled",
+                                  invoice_id:             payment_attempt.invoice_id)
+    end
+
+    it "builds payment attempt failures with the record and extra metadata" do
+      service_class = Class.new(described_class) do
+        param :payment_attempt
+
+        def call
+          payment_attempt_failure(:system_error, payment_attempt, retryable: true)
+        end
+      end
+
+      result = service_class.call(payment_attempt)
+
+      expect(result).to be_failure
+      expect(result.failure.first).to eq(:system_error)
+      expect(result.failure.last).to include(payment_attempt:        payment_attempt,
+                                             payment_attempt_id:     payment_attempt.id,
+                                             payment_attempt_status: "scheduled",
+                                             invoice_id:             payment_attempt.invoice_id,
+                                             retryable:              true)
+    end
+
+    it "keeps structured payment attempt metadata when extra metadata conflicts" do
+      replacement_attempt = FactoryBot.create(:payment_attempt)
+      service_class = Class.new(described_class) do
+        param :payment_attempt
+        param :replacement_attempt
+
+        def call
+          payment_attempt_failure(:system_error,
+                                  payment_attempt,
+                                  payment_attempt:        replacement_attempt,
+                                  payment_attempt_id:     "wrong",
+                                  payment_attempt_status: "wrong",
+                                  invoice_id:             "wrong")
+        end
+      end
+
+      result = service_class.call(payment_attempt, replacement_attempt)
+
+      expect(result.failure.last).to include(payment_attempt:        payment_attempt,
+                                             payment_attempt_id:     payment_attempt.id,
+                                             payment_attempt_status: "scheduled",
+                                             invoice_id:             payment_attempt.invoice_id)
+    end
+  end
+
   describe ".input_schema" do
     let(:subscription) { FactoryBot.create(:subscription) }
 

--- a/spec/services/process_payment_service_spec.rb
+++ b/spec/services/process_payment_service_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe ProcessPaymentService, type: :service do
         expect(result.failure.first).to eq :insufficient_funds
       end
 
+      it "returns shared payment attempt failure metadata" do
+        result = described_class.call(payment_attempt, payment_gateway)
+
+        expect(result.failure.last).to include(payment_attempt:        payment_attempt,
+                                               payment_attempt_id:     payment_attempt.id,
+                                               payment_attempt_status: "failed",
+                                               invoice_id:             payment_attempt.invoice_id)
+      end
+
       it "marks the payment attempt as failed" do
         result = described_class.call(payment_attempt, payment_gateway)
         expect(result.failure.last.fetch(:payment_attempt).failed?).to be(true)


### PR DESCRIPTION
Add shared ApplicationService helpers for structured failure results, subscription metadata, and payment-attempt metadata.

Move ProcessPaymentService onto the shared payment-attempt failure helper and add coverage for metadata conflict handling. Also add Makefile lint/check targets.

Entire-Checkpoint: c61a67248234